### PR TITLE
Index fixes

### DIFF
--- a/issues/8407/116 Kurvendiskussion Hires-Grafik mit Hardcopy-Funktion.html
+++ b/issues/8407/116 Kurvendiskussion Hires-Grafik mit Hardcopy-Funktion.html
@@ -12,7 +12,7 @@
     <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_title" content="Kurvendiskussion in HiRes-Grafik (C 64)">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
-    <meta name="64er.index_title" content="Kurvendiskussion in HiRes-Grafik mit Hardcopy">
+    <meta name="64er.index_title" content="Kurvendiskussion in Hires-Grafik mit Hardcopy">
     <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|Funktionen">
     <meta name="64er.id" content="kurvendiskussion">
 </head>

--- a/issues/8407/122 Rätsel - ein Knobelprogramm.html
+++ b/issues/8407/122 Rätsel - ein Knobelprogramm.html
@@ -12,7 +12,7 @@
     <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_title" content="Rätsel - ein Knobelprogramm (VC 20)">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Spiele">
-    <meta name="64er.index_title" content="Rätsel - ein Knobelprogramm (VC 20)">
+    <meta name="64er.index_title" content="Rätsel – ein Knobelprogramm (VC 20)">
     <meta name="64er.index_category" content="Listings zum Abtippen|Spiel|Denkspiel">
     <meta name="64er.id" content="rätsel">
 </head>

--- a/issues/8407/154 Strubs – Ein Precompiler für Basic-Programme (Teil 4).html
+++ b/issues/8407/154 Strubs – Ein Precompiler für Basic-Programme (Teil 4).html
@@ -11,7 +11,7 @@
     <meta name="64er.head1" content="Strubs">
     <meta name="64er.toc_title" content="Strubs - ein Precompiler für Basicprogramme (4)">
     <meta name="64er.toc_category" content="Kurse">
-    <meta name="64er.index_title" content="Strubs – Ein Precompiler für Basic-Programme (Teil 4)">
+    <meta name="64er.index_title" content="Strubs – ein Precompiler für Basic-Programme (Teil 4)">
     <meta name="64er.index_category" content="Kurse|Precompiler">
     <meta name="64er.id" content="strubs">
 </head>

--- a/issues/8407/68 Lode Runner.html
+++ b/issues/8407/68 Lode Runner.html
@@ -10,7 +10,7 @@
     <meta name="64er.pages" content="68">
     <meta name="64er.toc_category" content="Spiele-Test">
     <meta name="64er.index_title" content="Loderunner">
-    <meta name="64er.index_category" content="Spiele-Text|Action">
+    <meta name="64er.index_category" content="Spiele-Test|Action">
     <meta name="64er.id" content="lode_runner">
 </head>
 

--- a/issues/8407/68 Zaxxon - Zu große Erwartung.html
+++ b/issues/8407/68 Zaxxon - Zu große Erwartung.html
@@ -11,7 +11,7 @@
     <meta name="64er.toc_title" content="Zaxxon">
     <meta name="64er.toc_category" content="Spiele-Test">
     <meta name="64er.index_title" content="Zaxxon">
-    <meta name="64er.index_category" content="Spiele-Text|Zaxxon">
+    <meta name="64er.index_category" content="Spiele-Test|Action">
     <meta name="64er.id" content="zaxxon">
 </head>
 

--- a/issues/8407/69 Flight II – Fast wie richtiges Fliegen.html
+++ b/issues/8407/69 Flight II – Fast wie richtiges Fliegen.html
@@ -11,7 +11,7 @@
     <meta name="64er.toc_title" content="Flight II – fast wie richtiges Fliegen">
     <meta name="64er.toc_category" content="Spiele-Test">
     <meta name="64er.index_title" content="Flight II – fast wie richtiges Fliegen">
-    <meta name="64er.index_category" content="Spiele-Text|Simulation">
+    <meta name="64er.index_category" content="Spiele-Test|Simulation">
     <meta name="64er.id" content="flight_ii">
 </head>
 

--- a/issues/8407/80 Crown No. 1 – der C 64 als Spielautomat.html
+++ b/issues/8407/80 Crown No. 1 – der C 64 als Spielautomat.html
@@ -11,7 +11,7 @@
     <meta name="64er.head1" content="Leserservice">
     <meta name="64er.toc_title" content="Crown No. 1 (C 64)">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Anwendungen">
-    <meta name="64er.index_title" content="Crown No. 1">
+    <meta name="64er.index_title" content="Crown No 1">
     <meta name="64er.index_category" content="Listings zum Abtippen|Spiel|Spielhalle">
     <meta name="64er.id" content="crown">
 </head>

--- a/issues/8407/82 Vollautomatisches Blumengießen.html
+++ b/issues/8407/82 Vollautomatisches Blumengießen.html
@@ -11,7 +11,7 @@
     <meta name="64er.head1" content="Anwendung des Monats">
     <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Anwendung des Monats">
-    <meta name="64er.index_title" content="Blumen gießen mit dem C64 (AdM)">
+    <meta name="64er.index_title" content="Blumen gießen mit dem C 64 (AdM)">
     <meta name="64er.index_category" content="Listings zum Abtippen|Anwendung|User-Port">
     <meta name="64er.id" content="blumengießen">
 </head>

--- a/issues/8407/85 Das erste »Strubs«-Listing.html
+++ b/issues/8407/85 Das erste »Strubs«-Listing.html
@@ -11,7 +11,7 @@
     <meta name="64er.head1" content="Erstes Strubs-Listing">
     <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Anwendungen">
-    <meta name="64er.index_title" content="Das erste Strubs Listing (VC 20)">
+    <meta name="64er.index_title" content="Das erste Strubs-Listing (VC 20)">
     <meta name="64er.index_category" content="Listings zum Abtippen|Anwendung|Strubs">
     <meta name="64er.id" content="erstes_strubs">
 </head>


### PR DESCRIPTION
Fixes for mistakes I made when adding the index-titles and categories.

Mostly minor spelling changes to reflect the spelling in the printed index, except "Lode Runner", "Zaxxon" and "Flight II", which are proper errors.

(Removing the dot in the "Crown No 1" entry is rather pedantic, so I'm not even sure about this one).