### PR TITLE
More tables plus a listing

### DIFF
--- a/issues/8408/102 Die große Software-Vielfalt der CBMs für den C 64 ausnützen.html
+++ b/issues/8408/102 Die große Software-Vielfalt der CBMs für den C 64 ausnützen.html
@@ -129,7 +129,21 @@
         <p>Beispiel (hier für C 64): Wir wollen für ein Spielprogramm eine Kanone (↑haben, die man am unteren Bildschirmrand mit Taste ”1” nach links und mit Taste ”2” nach rechts steuern kann. In unserem Beispiel würde das Programm entsprechend Listing 1 aussehen.</p>
 
         <figure>
-            <!-- TODO -->
+            <pre>
+1 REM KANONE
+5 ZA = 1984:ZE = 2023:OP = 2004
+10 DIM A%(255)
+20 A%(56) = –1:A%(59) = 1
+:
+1000 REM Abfrage - Zeichen setzen, Subroutine
+1010 NP = OP + A%(PEEK(203)):REM neue Position
+1020 IF NP&gt;ZE OR NP&lt;ZA THEN NP = OP: REM Zeilenbegrenzung
+1030 POKE OP, 32:REM alte Position löschen
+1040 POKE NP, 30:REM neue Position setzen
+1050 POKE NP+54272,1:REM Farbe setzen
+1060 OP = NP
+1070 RETURN
+</pre>
             <figcaption>Listing 1. Ein kleines Beispielprogramm für den C 64.</figcaption>
         </figure>
 
@@ -216,7 +230,79 @@
             (Adresse = 54272 + Register)</p>
 
         <figure>
-            <!-- TODO -->
+            <table>
+                <tr>
+                    <th></th>
+                    <th colspan="3">REGISTER</th>
+                    <th colspan="2">INHALT</th>
+                </tr>
+                <tr>
+                    <th>Stimme</th>
+                    <th>2</th>
+                    <th>2</th>
+                    <th>3</th>
+                    <th colspan="2"></th>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td>0</td>
+                    <td>7</td>
+                    <td>14</td>
+                    <td colspan="2">Frequenz Low-Byte (0-255)</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td>1</td>
+                    <td>8</td>
+                    <td>15</td>
+                    <td colspan="2">Frequenz High-Byte (0-255)</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td>2</td>
+                    <td>9</td>
+                    <td>16</td>
+                    <td colspan="2">Tastverhältnis Low-Byte (0-255)</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td>3</td>
+                    <td>10</td>
+                    <td>17</td>
+                    <td colspan="2">Tastverhältnis High-Byte (0-255)</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td>4</td>
+                    <td>11</td>
+                    <td>18</td>
+                    <td>Wellenform:</td>
+                    <td>Rauschen = 129<br>Rechteck = 65<br>Sägezahn = 33<br>Dreieck = 17</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td>5</td>
+                    <td>12</td>
+                    <td>19</td>
+                    <td>Anschlag<br>0 (hart) – 15*16 (weich)</td>
+                    <td>+ Abschwellen<br>0 (hart) – 15 (weich)</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td>6</td>
+                    <td>13</td>
+                    <td>20</td>
+                    <td>Halten<br>0 (stumm) – 15*16 (laut)</td>
+                    <td>+ Ausklingen<br>0 (schnell) – 15 (langsam)</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td>24</td>
+                    <td>24</td>
+                    <td>24</td>
+                    <td colspan="2">Lautstärke: 0 (stumm) – 15 (volle Lautstärke)</td>
+                </tr>
+            </table>
             <figcaption>Tabelle 3. Die wichtigsten Tonadressen von C 64.</figcaption>
         </figure>
 
@@ -234,7 +320,186 @@
         <p>Zum Schluß noch einige wichtige Zero-Page-Adressen zum Vergleich in Tabelle 5 (aus urheberrechtlichen Gründen dürfen die vollständigen Listen leider nicht abgedruckt werden).</p>
 
         <figure>
-            <!-- TODO -->
+            <table>
+                <tr>
+                    <th colspan="2">CBM</th>
+                    <th colspan="2">C64</th>
+                    <th>Bedeutung</th>
+                </tr>
+                <tr>
+                    <th>Hex</th>
+                    <th>Dezimal</th>
+                    <th>Hex</th>
+                    <th>Dezimal</th>
+                    <th></th>
+                </tr>
+                <tr>
+                    <td>0028-0029</td>
+                    <td>40-41</td>
+                    <td>002B-002C</td>
+                    <td>43-44</td>
+                    <td>Zeiger auf Basic-Anfang</td>
+                </tr>
+                <tr>
+                    <td>002A-002B</td>
+                    <td>42-43</td>
+                    <td>002D-002E</td>
+                    <td>45-46</td>
+                    <td>Zeiger auf Variablen Anfang</td>
+                </tr>
+                <tr>
+                    <td>002C-002D</td>
+                    <td>44-45</td>
+                    <td colspan="2">s.u.</td>
+                    <td>Zeiger auf Ende der Variablentabelle</td>
+                </tr>
+                <tr>
+                    <td colspan="2">s.o.</td>
+                    <td>002F-0030</td>
+                    <td>47-48</td>
+                    <td>Zeiger auf Beginn der Felder</td>
+                </tr>
+                <tr>
+                    <td>002E-002F</td>
+                    <td>46-47</td>
+                    <td>0031-0032</td>
+                    <td>49-50</td>
+                    <td>Zeiger auf Ende der Felder</td>
+                </tr>
+                <tr>
+                    <td>0030-0031</td>
+                    <td>48-49</td>
+                    <td>0033-0034</td>
+                    <td>51-52</td>
+                    <td>Zeiger auf Beginn der Strings (rückwärts)</td>
+                </tr>
+                <tr>
+                    <td>0032-0033</td>
+                    <td>50-51</td>
+                    <td>0037-0038</td>
+                    <td>55-56</td>
+                    <td>Zeiger auf Ende der Strings (= Speichergrenze)</td>
+                </tr>
+                <tr>
+                    <td>0036-0037</td>
+                    <td>54-55</td>
+                    <td>0039-003A</td>
+                    <td>57-58</td>
+                    <td>laufende Zeilennummer</td>
+                </tr>
+                <tr>
+                    <td>0038-0039</td>
+                    <td>56-57</td>
+                    <td>003B-003C</td>
+                    <td>59-60</td>
+                    <td>vorhergehende Zeilennummer</td>
+                </tr>
+                <tr>
+                    <td>003A-0038<!-- sic! --></td>
+                    <td>58-59</td>
+                    <td>003D-003E</td>
+                    <td>61-62</td>
+                    <td>nächster Befehl (für CONT)</td>
+                </tr>
+                <tr>
+                    <td>003C-003D</td>
+                    <td>60-61</td>
+                    <td>003F-0040</td>
+                    <td>63-64</td>
+                    <td>aktuelle DATA-Zeile</td>
+                </tr>
+                <tr>
+                    <td>003E-003F</td>
+                    <td>62-63</td>
+                    <td>0041-0042</td>
+                    <td>65-66</td>
+                    <td>aktuelles DATA-Element (Adresse)</td>
+                </tr>
+                <tr>
+                    <td>0042-0043</td>
+                    <td>66-67</td>
+                    <td>0045-0046</td>
+                    <td>69-70</td>
+                    <td>aktueller Variablenname</td>
+                </tr>
+                <tr>
+                    <td>0044-0045</td>
+                    <td>68-69</td>
+                    <td>0047-0048</td>
+                    <td>71-72</td>
+                    <td>Zeiger auf aktuelle Variable</td>
+                </tr>
+                <tr>
+                    <td>0046-0047</td>
+                    <td>70-71</td>
+                    <td>0049-004A</td>
+                    <td>73-74</td>
+                    <td>Variablenzeiger für FOR...NEXT</td>
+                </tr>
+                <tr>
+                    <td>0070-0087</td>
+                    <td>112-135</td>
+                    <td>0073-008A</td>
+                    <td>115-138</td>
+                    <td>diese Routine holt nächstes Basic-Zeichen</td>
+                </tr>
+                <tr>
+                    <td>0088-008C</td>
+                    <td>136-140</td>
+                    <td>008B-008F</td>
+                    <td>139-143</td>
+                    <td>Zufallszahl</td>
+                </tr>
+                <tr>
+                    <td>008D-008F</td>
+                    <td>141-143</td>
+                    <td>00A0-00A2</td>
+                    <td>160-162</td>
+                    <td>interne Uhr</td>
+                </tr>
+                <tr>
+                    <td>0097</td>
+                    <td>151</td>
+                    <td>00CB</td>
+                    <td>203</td>
+                    <td>gedrückte Taste</td>
+                </tr>
+                <tr>
+                    <td>00A7</td>
+                    <td>167</td>
+                    <td>00CC</td>
+                    <td>204</td>
+                    <td>Cursor an/aus (0=an,1=aus)</td>
+                </tr>
+                <tr>
+                    <td>00C6</td>
+                    <td>198</td>
+                    <td>00CA</td>
+                    <td>202</td>
+                    <td>Spaltenposition des Eingabecursors</td>
+                </tr>
+                <tr>
+                    <td>00D8</td>
+                    <td>216</td>
+                    <td>00C9</td>
+                    <td>201</td>
+                    <td>Zeilenposition des Eingabecursors</td>
+                </tr>
+                <tr>
+                    <td>00FD-00FF</td>
+                    <td>253-255</td>
+                    <td>00FB-00FE</td>
+                    <td>251-254</td>
+                    <td>freier Platz für Zeiger in Page 0</td>
+                </tr>
+                <tr>
+                    <td>026F-0278</td>
+                    <td>623-632</td>
+                    <td>0277-0280</td>
+                    <td>631-640</td>
+                    <td>Tastaturpuffer</td>
+                </tr>
+            </table>
             <figcaption>Tabelle 5. Die wichtigsten Zero-Page Adressen</figcaption>
         </figure>
 

--- a/issues/8408/56 Neues vom VC 20 Videochip.html
+++ b/issues/8408/56 Neues vom VC 20 Videochip.html
@@ -167,7 +167,92 @@
         <p>Die Tabelle 1 zeigt die für unsere Zwecke wichtigsten Register des Video-Chips sowie deren Funktion.</p>
 
         <figure>
-            <!-- TODO -->
+            <table>
+                <tr>
+                    <th class="separator">Adresse / BIT</th>
+                    <th class="separator"></th>
+                    <th class="separator">7</th>
+                    <th class="separator">6</th>
+                    <th class="separator">5</th>
+                    <th class="separator">4</th>
+                    <th class="separator"> </th>
+                    <th class="separator">3</th>
+                    <th class="separator">2</th>
+                    <th class="separator">1</th>
+                    <th class="separator">0</th>
+                    <th class="separator"></th>
+                </tr>
+                <tr>
+                    <td>36864 =</td>
+                    <td></td>
+                    <td>–</td>
+                    <td>HZ</td>
+                    <td>HZ</td>
+                    <td>HZ</td>
+                    <td></td>
+                    <td>HZ</td>
+                    <td>HZ</td>
+                    <td>HZ</td>
+                    <td>HZ</td>
+                    <td>: Horizontal-Zentrierung</td>
+                </tr>
+                <tr>
+                    <td>36865 =</td>
+                    <td></td>
+                    <td>VZ</td>
+                    <td>VZ</td>
+                    <td>VZ</td>
+                    <td>VZ</td>
+                    <td></td>
+                    <td>VZ</td>
+                    <td>VZ</td>
+                    <td>VZ</td>
+                    <td>VZ</td>
+                    <td>: Vertikal-Zentrierung</td>
+                </tr>
+                <tr>
+                    <td>36866 =</td>
+                    <td></td>
+                    <td>BA</td>
+                    <td>ZE</td>
+                    <td>ZE</td>
+                    <td>ZE</td>
+                    <td></td>
+                    <td>ZE</td>
+                    <td>ZE</td>
+                    <td>ZE</td>
+                    <td>ZE</td>
+                    <td>: Bildschirm-Adresse<br>: ZEichen pro Zeile</td>
+                </tr>
+                <tr>
+                    <td>36867 =</td>
+                    <td></td>
+                    <td>–</td>
+                    <td>ZL</td>
+                    <td>ZL</td>
+                    <td>ZL</td>
+                    <td></td>
+                    <td>ZL</td>
+                    <td>ZL</td>
+                    <td>ZL</td>
+                    <td>MA</td>
+                    <td>: ZeiLen-Anzahl<br>: Matrix: (8*8 / 8*16)</td>
+                </tr>
+                <tr>
+                    <td>36869 =</td>
+                    <td></td>
+                    <td>BA</td>
+                    <td>BA</td>
+                    <td>BA</td>
+                    <td>BA</td>
+                    <td></td>
+                    <td>ZA</td>
+                    <td>ZA</td>
+                    <td>ZA</td>
+                    <td>ZA</td>
+                    <td>: Bildschirm-Adresse<br>: Zeichensatz-Adresse</td>
+                </tr>
+            </table>
             <figcaption>Tabelle 1. Einige wenig bekannte, aber recht nützliche Register des VIC-Chips.</figcaption>
         </figure>
 


### PR DESCRIPTION
I think the remaining tables would be rather tedious to type in, maybe you can just include them as scans?

Also, I'm not sure what to do with the "Listing 1" of page 102 "Die große Software-Vielfalt...":

It's similar to the Listing at the end of the article, which you already added, so I copied and adapted that for now. But "Listing 1" looks more like a proper listing in that the text after the `REM`'s is all caps, but it still isn't really as it has the colon between lines 20 and 1000 and the umlaut in line 1030. But *if* you'd like to treat it as a real listing, I'd ignore these two and convert it to something that can be piped through `petcat` or copy/pasted into an emulator. What do you think?