### PR TITLE
8408: Add head1/head2 tags

### DIFF
--- a/issues/8408/101 »PRINT AT« und »RESTORE N«.html
+++ b/issues/8408/101 »PRINT AT« und »RESTORE N«.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Jürgen Reinert, ev">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="101">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.toc_title" content="PRINT AT und RESTORE N (VC 20)">
     <meta name="64er.index_title" content="PRINT AT und RESTORE N (VC 20)">

--- a/issues/8408/102 Die große Software-Vielfalt der CBMs für den C 64 ausnützen.html
+++ b/issues/8408/102 Die große Software-Vielfalt der CBMs für den C 64 ausnützen.html
@@ -8,6 +8,8 @@
     <meta name="author" content="M. und J. Heinz, rg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="102-105">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.toc_title" content="Die große Software-Vielfalt der CBMs für den C 64">
     <meta name="64er.index_title" content="Die Software-Vielfalt der CBMs für den C 64 nutzen">

--- a/issues/8408/105 Tips & Tricks.html
+++ b/issues/8408/105 Tips & Tricks.html
@@ -7,6 +7,8 @@
     <link rel="stylesheet" href="../style.css">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="105">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.id" content="tips">
 </head>

--- a/issues/8408/114 Elektronische Aquarelle.html
+++ b/issues/8408/114 Elektronische Aquarelle.html
@@ -8,6 +8,7 @@
     <meta name="author" content="Markus Braun, wg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="114-116">
+    <meta name="64er.head1" content="Software-Test">
     <meta name="64er.toc_category" content="Software-Test">
     <meta name="64er.toc_title" content="Elektronische Aquarelle – Paint Magic">
     <meta name="64er.index_title" content="Elektronische Aquarelle: Paint Magic">

--- a/issues/8408/117 ISM 64 – ohne Fleiß kein Preis.html
+++ b/issues/8408/117 ISM 64 – ohne Fleiß kein Preis.html
@@ -8,6 +8,8 @@
     <meta name="author" content="H. J. Schlicht, rg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="117-119">
+    <meta name="64er.head1" content="Software-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Software-Test">
     <meta name="64er.toc_title" content="Software-Test: ISM 64 – leistungsfähige Datenbanken schnell erstellt">
     <meta name="64er.index_title" content="ISM 64 – ohne Fleiß kein Preis">

--- a/issues/8408/136 One on One.html
+++ b/issues/8408/136 One on One.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Martin Gaksch, gk">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="136">
+    <meta name="64er.head1" content="Spiele-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">
     <meta name="64er.toc_title" content="One on One (C 64)">
     <meta name="64er.index_title" content="One on One">

--- a/issues/8408/137 Gruds in Space.html
+++ b/issues/8408/137 Gruds in Space.html
@@ -8,6 +8,8 @@
     <meta name="author" content="F.O. Malisch">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="137">
+    <meta name="64er.head1" content="Spiele-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">
     <meta name="64er.toc_title" content="Gruds in Space (C 64)">
     <meta name="64er.index_title" content="Gruds in Space">

--- a/issues/8408/138 Los Angeles läßt grüßen.html
+++ b/issues/8408/138 Los Angeles läßt grüßen.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Heinrich Lenhardt">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="138">
+    <meta name="64er.head1" content="Spiele-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">
     <meta name="64er.toc_title" content="Olympic Games (C 64)"> <!-- sic! -->
     <meta name="64er.index_title" content="Summer Games — Los Angeles läßt grüßen">

--- a/issues/8408/142 Reise durch die Wunderwelt der Grafik – Teil 5.html
+++ b/issues/8408/142 Reise durch die Wunderwelt der Grafik – Teil 5.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Heimo Ponnath, aa">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="142-150">
+    <meta name="64er.head1" content="Grafik-Grundlagen">
+    <meta name="64er.head2" content="C 64-Kurs">
     <meta name="64er.toc_category" content="Kurse">
     <meta name="64er.toc_title" content="Reise durch die Wunderwelt der Grafik (5)">
     <meta name="64er.index_title" content="Reise durch die Wunderwelt der Grafik (Teil 5)">

--- a/issues/8408/151 Alle Tasten-, Zeichen- und Steuercodes – 4. Teil und Schluß.html
+++ b/issues/8408/151 Alle Tasten-, Zeichen- und Steuercodes – 4. Teil und Schluß.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Dr. Helmuth Hauck, gk">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="151-155">
+    <meta name="64er.head1" content="Alle Codes">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Kurse">
     <meta name="64er.toc_title" content="Alle Tasten-, Zeichen- und Steuercodes (4)">
     <meta name="64er.index_title" content="Alle Tasten-, Zeichen- und Steuercodes (Teil 4)">

--- a/issues/8408/156 Der Computer im Kuhstall.html
+++ b/issues/8408/156 Der Computer im Kuhstall.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Willi Lackenbauer, kg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="156-160">
+    <meta name="64er.head1" content="So machen's andere">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="So machen's andere">
     <meta name="64er.toc_title" content="Der C 64 im Kuhstall">
     <meta name="64er.index_title" content="Der Computer im Kuhstall">

--- a/issues/8408/20 MPS-801.html
+++ b/issues/8408/20 MPS-801.html
@@ -8,6 +8,7 @@
     <meta name="author" content="Reinhard Schrutzki, gk">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="20-22">
+    <meta name="64er.head1" content="Hardware">
     <meta name="64er.toc_category" content="Test">
     <meta name="64er.toc_title" content="Drucker MPS 801">
     <meta name="64er.index_title" content="MPS-801 — Ein Erfahrungsbericht">

--- a/issues/8408/22 Sprachausgabe mit dem SDP 120.html
+++ b/issues/8408/22 Sprachausgabe mit dem SDP 120.html
@@ -8,6 +8,7 @@
     <meta name="author" content="Christian Quirin Spitzner, rg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="22-23">
+    <meta name="64er.head1" content="Hardware-Test">
     <meta name="64er.toc_category" content="Test">
     <meta name="64er.toc_title" content="Sprachausgabe mit dem SDP">
     <meta name="64er.index_title" content="Sprachausgabe mit dem SDP 120">

--- a/issues/8408/24 Geheimnissen auf der Spur.html
+++ b/issues/8408/24 Geheimnissen auf der Spur.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Arnd Wängler">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="24-27">
+    <meta name="64er.head1" content="Hardware">
+    <meta name="64er.head2" content="VC 1541">
     <meta name="64er.toc_category" content="Hardware">
     <meta name="64er.toc_title" content="Keine Probleme mit der Floppy – Selbsthilfe: VC 1541-Tricks">
     <meta name="64er.index_title" content="Geheimnissen auf der Spur: 1541 reparieren">

--- a/issues/8408/28 Modem + Akkustikkoppler Marktübersicht.html
+++ b/issues/8408/28 Modem + Akkustikkoppler Marktübersicht.html
@@ -8,6 +8,7 @@
     <meta name="author" content="rg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="28-29, 33">
+    <meta name="64er.head1" content="Hardware">
     <meta name="64er.toc_category" content="Hardware">
     <meta name="64er.toc_title" content="Große Übersicht: Modems Akustikkoppler">
     <meta name="64er.index_title" content="Akkustikkoppler und Modems: Marktübersicht">

--- a/issues/8408/30 Commodore 64 im neuen Kleid.html
+++ b/issues/8408/30 Commodore 64 im neuen Kleid.html
@@ -8,6 +8,8 @@
     <meta name="author" content="H. Schröder, A. Wängler, gk">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="30-32">
+    <meta name="64er.head1" content="Hardware">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Hardware">
     <meta name="64er.toc_title" content="Der C 64 im neuen Kleid">
     <meta name="64er.index_title" content="Commodore im neuen Kleid">

--- a/issues/8408/34 RESET am C64.html
+++ b/issues/8408/34 RESET am C64.html
@@ -8,6 +8,8 @@
     <meta name="author" content="A. Wängler, rg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="34-35">
+    <meta name="64er.head1" content="Hardware">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Hardware">
     <meta name="64er.toc_title" content="Reset am C64">
     <meta name="64er.index_title" content="Resetschalter am C 64">

--- a/issues/8408/36 Programmodule selbst gemacht – Vergleichstest Eprom-Brenner.html
+++ b/issues/8408/36 Programmodule selbst gemacht – Vergleichstest Eprom-Brenner.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Arnd Wängler, gk">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="36-37,40">
+    <meta name="64er.head1" content="Hardware-Test">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Hardware">
     <meta name="64er.toc_title" content="Vergleichstest: EPROM-Brenner">
     <meta name="64er.index_title" content="EPROM-Brenner: Vergleichstest">

--- a/issues/8408/41 Comal.html
+++ b/issues/8408/41 Comal.html
@@ -8,6 +8,8 @@
     <meta name="author" content="rg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="41-43">
+    <meta name="64er.head1" content="Software">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Software">
     <meta name="64er.toc_title" content="Tuning durch andere Sprachen – ist Basic out?<br>Was ist Comal?">
     <meta name="64er.index_title" content="Was ist Comal?">

--- a/issues/8408/44 Pascal – leistungsfähiger und eleganter als Basic.html
+++ b/issues/8408/44 Pascal – leistungsfähiger und eleganter als Basic.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Martin Baur">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="44,46,48,50,52,54,163">
+    <meta name="64er.head1" content="Software">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Software">
     <meta name="64er.toc_title" content="Pascal – leistungsfähiger und eleganter als Basic (2)">
     <meta name="64er.index_title" content="Pascal – leistungsfähiger und eleganter als Basic (Teil 2)">

--- a/issues/8408/56 Neues vom VC 20 Videochip.html
+++ b/issues/8408/56 Neues vom VC 20 Videochip.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Heino Verder, ev">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="56-60,62">
+    <meta name="64er.head1" content="Software">
+    <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Software">
     <meta name="64er.toc_title" content="So nutzt man den Videochip des VC 20 voll aus">
     <meta name="64er.index_title" content="Neues vom Video-Chip beim VC 20">

--- a/issues/8408/63 Datenkreislauf – Die sequentielle Datenspeicherung.html
+++ b/issues/8408/63 Datenkreislauf – Die sequentielle Datenspeicherung.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Christian Schlüter, gk">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="63-65">
+    <meta name="64er.head1" content="Software">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Software">
     <meta name="64er.index_title" content="Datenkreislauf: Die sequentielle Datenspeicherung">
     <meta name="64er.index_category" content="Software|Grundlagen">

--- a/issues/8408/66 Listing des Monats- Castle of Doom.html
+++ b/issues/8408/66 Listing des Monats- Castle of Doom.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Bernd Weißbecker, gk">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="66-67,106-111">
+    <meta name="64er.head1" content="Listing des Monats">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Listing des Monats">
     <meta name="64er.toc_title" content="Das außergewöhnliche Abenteuerspiel – Burg des Grauens (C 64)<br>Lebenslauf — Bilder">
     <meta name="64er.index_title" content="Castle of Doom — Adventure (LdM)">

--- a/issues/8408/68 Abgerechnet wird mit dem C 64.html
+++ b/issues/8408/68 Abgerechnet wird mit dem C 64.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Gerhard Schröter, rg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="68-72">
+    <meta name="64er.head1" content="Anwendung des Monats">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Anwendung des Monats">
     <meta name="64er.index_title" content="Abgerechnet wird mit dem C 64 (AdM)">
     <meta name="64er.index_category" content="Listings zum Abtippen|Anwendung|Finanzen">

--- a/issues/8408/73 Kopplung über den User-Port.html
+++ b/issues/8408/73 Kopplung über den User-Port.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Johannes Mockenhaupt, rg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="73-76">
+    <meta name="64er.head1" content="Anwendung">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Anwendungen">
     <meta name="64er.toc_title" content="Kopplung über den User-Port (C 64)"> <!-- sic! -->
     <meta name="64er.index_title" content="Kopplung über den User-Port (VC 20)"> <!-- sic! -->

--- a/issues/8408/77 Drucker,Floppy ein- oder ausgeschaltet.html
+++ b/issues/8408/77 Drucker,Floppy ein- oder ausgeschaltet.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Werner Pfeil, gk">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="77">
+    <meta name="64er.head1" content="Anwendung">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Anwendungen">
     <meta name="64er.toc_title" content="Drucker/Floppy ein- oder ausgeschaltet">
     <meta name="64er.index_title" content="Drucker/Floppy ein- oder ausgeschaltet?">

--- a/issues/8408/78 Analoger Meßwert rein — analoger Stellwert raus.html
+++ b/issues/8408/78 Analoger Meßwert rein — analoger Stellwert raus.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Dr. Ernst Breitz, rg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="78-79">
+    <meta name="64er.head1" content="Anwendung">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Anwendungen">
     <meta name="64er.toc_title" content="Analoger Meßwert rein — analoger Stellwert raus (C 64)">
     <meta name="64er.index_title" content="Analoger Meßwert rein — analoger Stellwert raus">

--- a/issues/8408/80 »Kudiplo« erfüllt Schülerträume.html
+++ b/issues/8408/80 »Kudiplo« erfüllt Schülerträume.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Jürgen Curdt, ev">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="80-82">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="VC 20+3 KByte">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
     <meta name="64er.toc_title" content="Kudiplo erfüllt Schülerträume (VC 20)">
     <meta name="64er.index_title" content="Kudiplo erfüllt Schülerträume (Kurvendiskussion auf dem VC 20)">

--- a/issues/8408/83 Hardcopy für den Sieger.html
+++ b/issues/8408/83 Hardcopy für den Sieger.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Frank Lonczewski, gk">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="83-85">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
     <meta name="64er.toc_title" content="Hardcopy für Görlitz-Interface">
     <meta name="64er.index_title" content="Hardcopy für den Sieger (FX-80 mit Görlitz-Interface)">

--- a/issues/8408/86 ESCAPE.html
+++ b/issues/8408/86 ESCAPE.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Michale Werner, ev">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="86-89">
+    <meta name="64er.head1" content="Spiel">
+    <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Spiele">
     <meta name="64er.toc_title" content="Escape (VC 20)">
     <meta name="64er.index_title" content="Escape (VC 20)">

--- a/issues/8408/89 Pac-Boy — die Herausforderung.html
+++ b/issues/8408/89 Pac-Boy — die Herausforderung.html
@@ -8,6 +8,8 @@
     <meta name="author" content="H. Schlangmann, rg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="89-95">
+    <meta name="64er.head1" content="Spiel">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Spiele">
     <meta name="64er.toc_title" content="Pac-Boy — die Herausforderung (C 64)">
     <meta name="64er.index_title" content="Pac-Boy — die Herausforderung">

--- a/issues/8408/96 Von den Kleinen auf die Großen.html
+++ b/issues/8408/96 Von den Kleinen auf die Großen.html
@@ -8,6 +8,8 @@
     <meta name="author" content="K. Petanides, rg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="96-97">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.toc_title" content="Von den Kleinen auf die Großen (C 64)">
     <meta name="64er.index_title" content="Von den Kleinen auf die Großen (C 64 - CBM)">

--- a/issues/8408/97 User-Port-Display.html
+++ b/issues/8408/97 User-Port-Display.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Jan Legenhausen, gk">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="97">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.toc_title" content="User-Port-Display (C 64)">
     <meta name="64er.index_title" content="User-Port-Display">

--- a/issues/8408/98 Autostart für den VC 20.html
+++ b/issues/8408/98 Autostart für den VC 20.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Dirk Rother, ev">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="98-99">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.toc_title" content="Autostart (VC 20)">
     <meta name="64er.index_title" content="Autostart für den VC 20">

--- a/issues/8408/99 View BAM.html
+++ b/issues/8408/99 View BAM.html
@@ -8,6 +8,8 @@
     <meta name="author" content="Jörg Schieb, gk">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="99-100">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.toc_title" content="View BAM (C 64)">
     <meta name="64er.index_title" content="View BAM">


### PR DESCRIPTION
I noticed that issue 08/84 was also still missing the `head1/2` tags.