### PR TITLE
8410: tags and some fixes

### DIFF
--- a/issues/8410/10 Das Klavier am C 64.html
+++ b/issues/8410/10 Das Klavier am C 64.html
@@ -5,7 +5,7 @@
     <title>Das Klavier am C 64</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Richard Aicher, aa">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="10">
     <meta name="64er.toc_category" content="Aktuell">

--- a/issues/8410/10 Super Disk Drive.html
+++ b/issues/8410/10 Super Disk Drive.html
@@ -5,7 +5,7 @@
     <title>Super Disk Drive</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="aa">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="10">
     <meta name="64er.toc_category" content="Aktuell">

--- a/issues/8410/100 Programmiertes LISTing- LISTX-Y.html
+++ b/issues/8410/100 Programmiertes LISTing- LISTX-Y.html
@@ -5,9 +5,11 @@
     <title>Programmiertes LISTing: LISTX-Y</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Fred Behringer, ev">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="100-102">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.index_title" content="Programmiertes LISTing: LIST X-Y">
     <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Listing">

--- a/issues/8410/102 Kopieren mit Komfort- Super Copy.html
+++ b/issues/8410/102 Kopieren mit Komfort- Super Copy.html
@@ -5,9 +5,11 @@
     <title>Kopieren mit Komfort: Super Copy</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Dietrich Weineck, gk">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="102-105">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.index_title" content="Kopieren mit Komfort: Super Copy">
     <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Floppy">

--- a/issues/8410/106 Apocalypse Now.html
+++ b/issues/8410/106 Apocalypse Now.html
@@ -5,9 +5,11 @@
     <title>Apocalypse Now</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Helmut Burgemeister, Helmut Bölcskei, rg">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="106-112">
+    <meta name="64er.head1" content="Spiel">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Spiele">
     <meta name="64er.index_title" content="Apocalypse now">
     <meta name="64er.index_category" content="Listings zum Abtippen|Spiel|Action">

--- a/issues/8410/11 Die Alternativen kommen.html
+++ b/issues/8410/11 Die Alternativen kommen.html
@@ -5,7 +5,7 @@
     <title>Die Alternativen kommen</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="aa">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="11">
     <meta name="64er.toc_category" content="Aktuell">

--- a/issues/8410/112 Epedemic.html
+++ b/issues/8410/112 Epedemic.html
@@ -5,9 +5,11 @@
     <title>Epedemic</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Wolf-D. Robrahn, ev">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="112-115">
+    <meta name="64er.head1" content="Spiel">
+    <meta name="64er.head2" content="VC 20+8 KByte">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Spiele">
     <meta name="64er.index_title" content="Epedemic (VC 20)">
     <meta name="64er.index_category" content="Listings zum Abtippen|Spiel|Taktik">

--- a/issues/8410/12 Kreatives Chaos.html
+++ b/issues/8410/12 Kreatives Chaos.html
@@ -5,7 +5,6 @@
     <title>Kreatives Chaos</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="12-13,176">
     <meta name="64er.toc_category" content="Aktuell">

--- a/issues/8410/146 Reise durch die Wunderwelt der Grafik - Teil 7.html
+++ b/issues/8410/146 Reise durch die Wunderwelt der Grafik - Teil 7.html
@@ -5,9 +5,11 @@
     <title>Reise durch die Wunderwelt der Grafik - Teil 7</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Heimo Ponnath, aa">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="146-149">
+    <meta name="64er.head1" content="Grafik-Kurs">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Kurse">
     <meta name="64er.index_title" content="Reise durch die Wunderwelt der Grafik (Teil 7)">
     <meta name="64er.index_category" content="Kurse|Grafik">

--- a/issues/8410/150 Assembler ist keine Alchimie – 2. Teil.html
+++ b/issues/8410/150 Assembler ist keine Alchimie – 2. Teil.html
@@ -5,9 +5,11 @@
     <title>Assembler ist keine Alchimie – 2. Teil</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Heimo Ponnath, aa">
     <meta name="64er.issue" content="10/84">
-    <meta name="64er.pages" content="150-152">
+    <meta name="64er.pages" content="150-152,179">
+    <meta name="64er.head1" content="Assembler-Kurs">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Kurse">
     <meta name="64er.index_title" content="Assembler ist keine Alchimie (Teil 2)">
     <meta name="64er.index_category" content="Kurse|Assembler">

--- a/issues/8410/153 In die Geheimnisse der Floppy eingetaucht – Teil 1.html
+++ b/issues/8410/153 In die Geheimnisse der Floppy eingetaucht – Teil 1.html
@@ -5,9 +5,11 @@
     <title>In die Geheimnisse der Floppy eingetaucht – Teil 1</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="K. Schramm, B. Schneider, gk">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="153-156">
+    <meta name="64er.head1" content="Floppy-Kurs">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Kurse">
     <meta name="64er.index_title" content="In die Geheimnisse der Floppy eingetaucht (Teil 1)">
     <meta name="64er.index_category" content="Kurse|Floppy">

--- a/issues/8410/157 Der gläserne VC 20 – Teil 2.html
+++ b/issues/8410/157 Der gläserne VC 20 – Teil 2.html
@@ -5,9 +5,11 @@
     <title>Der gläserne VC 20 – Teil 2</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Christoph Sauer, ev">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="157-164">
+    <meta name="64er.head1" content="Kurs">
+    <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Kurse">
     <meta name="64er.index_title" content="Der gläserne VC 20 (Teil 2)">
     <meta name="64er.index_category" content="Kurse|VC 20">

--- a/issues/8410/16 Leserforum.html
+++ b/issues/8410/16 Leserforum.html
@@ -5,7 +5,6 @@
     <title>Leserforum</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="16-19">
     <meta name="64er.toc_category" content="Rubriken">

--- a/issues/8410/166 Mit 4 Baud über den Balkon.html
+++ b/issues/8410/166 Mit 4 Baud über den Balkon.html
@@ -5,9 +5,11 @@
     <title>Mit 4 Baud über den Balkon</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="M. Schneider, D. Schwuchow, kg">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="166-171">
+    <meta name="64er.head1" content="So machen's andere">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="So machen's andere">
     <meta name="64er.index_title" content="Mit vier Baud über den Balkon">
     <meta name="64er.index_category" content="So machen’s andere|Lichttelefon">

--- a/issues/8410/172 Unterprogrammebibliothek- Sieger mit Maske.html
+++ b/issues/8410/172 Unterprogrammebibliothek- Sieger mit Maske.html
@@ -5,9 +5,11 @@
     <title>Unterprogrammebibliothek: Sieger mit Maske</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Jacques Effenberg, gk">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="172-176">
+    <meta name="64er.head1" content="Unterprogramm">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Wettbewerbe">
     <meta name="64er.index_title" content="Sieger mit Maske — Maskenerstellungsprogramm">
     <meta name="64er.index_category" content="Wettbewerbe|Unterprogramm">

--- a/issues/8410/178 64'er Disk-Ecke.html
+++ b/issues/8410/178 64'er Disk-Ecke.html
@@ -5,7 +5,6 @@
     <title>64'er Disk-Ecke</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="178">
     <meta name="64er.id" content="disk_ecke">

--- a/issues/8410/180 Vorschau.html
+++ b/issues/8410/180 Vorschau.html
@@ -5,7 +5,6 @@
     <title>Vorschau</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="180">
     <meta name="64er.toc_category" content="Rubriken">

--- a/issues/8410/20 Mehr Übersicht am Bildschirm – Test 40:80-Zeichenkarte.html
+++ b/issues/8410/20 Mehr Übersicht am Bildschirm – Test 40:80-Zeichenkarte.html
@@ -5,9 +5,11 @@
     <title>Mehr Übersicht am Bildschirm – Test 40/80-Zeichenkarte</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Christian Q. Spitzner, ev">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="20-21">
+    <meta name="64er.head1" content="Hardware-Test">
+    <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Hardware-Test">
     <meta name="64er.index_title" content="Mehr Übersicht am Bildschirm (VC 20)">
     <meta name="64er.index_category" content="Hardware-Test|80-Zeichenkarten">

--- a/issues/8410/22 X 100 — Farbig plotten und drucken.html
+++ b/issues/8410/22 X 100 — Farbig plotten und drucken.html
@@ -5,9 +5,10 @@
     <title>X 100 — Farbig plotten und drucken</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="gk">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="22">
+    <meta name="64er.head1" content="Hardware-Test">
     <meta name="64er.toc_category" content="Hardware-Test">
     <meta name="64er.index_title" content="Adcomp X100 — farbig plotten und drucken">
     <meta name="64er.index_category" content="Hardware-Test|Drucker">

--- a/issues/8410/23 Ein Drucker für alle Fälle- Epson FX 80.html
+++ b/issues/8410/23 Ein Drucker für alle Fälle- Epson FX 80.html
@@ -5,9 +5,10 @@
     <title>Ein Drucker für alle Fälle: Epson FX 80</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="gk">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="23">
+    <meta name="64er.head1" content="Hardware-Test">
     <meta name="64er.toc_category" content="Hardware-Test">
     <meta name="64er.index_title" content="Ein Drucker für alle Fälle: Epson FX-80">
     <meta name="64er.index_category" content="Hardware-Test|Drucker">

--- a/issues/8410/24 Brother HR-5C- Fast nicht zu hören.html
+++ b/issues/8410/24 Brother HR-5C- Fast nicht zu hören.html
@@ -5,9 +5,10 @@
     <title>Brother HR-5C: Fast nicht zu hören</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="gk">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="24">
+    <meta name="64er.head1" content="Hardware-Test">
     <meta name="64er.toc_category" content="Hardware-Test">
     <meta name="64er.index_title" content="Brother HR-5C: fast nicht zu hören">
     <meta name="64er.index_category" content="Hardware-Test|Drucker">

--- a/issues/8410/25 Ein Star, der es in sich hat.html
+++ b/issues/8410/25 Ein Star, der es in sich hat.html
@@ -5,9 +5,10 @@
     <title>Ein Star, der es in sich hat</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="gk">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="25">
+    <meta name="64er.head1" content="Hardware-Test">
     <meta name="64er.toc_category" content="Hardware-Test">
     <meta name="64er.index_title" content="Ein Star der es in sich hat (delta-10)">
     <meta name="64er.index_category" content="Hardware-Test|Drucker">

--- a/issues/8410/26 Seikoshas Größter- Test GP-550A.html
+++ b/issues/8410/26 Seikoshas Größter- Test GP-550A.html
@@ -5,9 +5,10 @@
     <title>Seikoshas Größter: Test GP-550A</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="gk">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="26">
+    <meta name="64er.head1" content="Hardware-Test">
     <meta name="64er.toc_category" content="Hardware-Test">
     <meta name="64er.index_title" content="Seikoshas Größter: Test GP-550A">
     <meta name="64er.index_category" content="Hardware-Test|Drucker">

--- a/issues/8410/27 Roland DXY-101 – ein Flachbettplotter im DIN-A3-Format.html
+++ b/issues/8410/27 Roland DXY-101 – ein Flachbettplotter im DIN-A3-Format.html
@@ -5,13 +5,14 @@
     <title>Roland DXY-101 – ein Flachbettplotter im DIN-A3-Format</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="gk">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="27">
+    <meta name="64er.head1" content="Hardware-Test">
     <meta name="64er.toc_category" content="Hardware-Test">
     <meta name="64er.index_title" content="Roland DXY-101 — ein Flachbettplotter im DIN-A3-Format">
     <meta name="64er.index_category" content="Hardware-Test|Drucker">
-    <meta name="64er.id" content="XXX">
+    <meta name="64er.id" content="dxy-101">
 </head>
 
 <body>

--- a/issues/8410/28 Schreibmaschine – anschlußfertig für den C 64.html
+++ b/issues/8410/28 Schreibmaschine – anschlußfertig für den C 64.html
@@ -5,9 +5,10 @@
     <title>Schreibmaschine – anschlußfertig für den C 64</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="gk">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="28">
+    <meta name="64er.head1" content="Hardware-Test">
     <meta name="64er.toc_category" content="Hardware-Test">
     <meta name="64er.index_title" content="Olympia electronic compact 2: Schreibmaschine für den C64">
     <meta name="64er.index_category" content="Hardware-Test|Drucker">

--- a/issues/8410/29 Marktübersicht- Drucker für C 64:VC 20.html
+++ b/issues/8410/29 Marktübersicht- Drucker für C 64:VC 20.html
@@ -5,9 +5,11 @@
     <title>Marktübersicht: Drucker für C 64/VC 20</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="ev">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="29-31">
+    <meta name="64er.head1" content="Hardware">
+    <meta name="64er.head2" content="Marktübersicht: Drucker">
     <meta name="64er.toc_category" content="Hardware-Test">
     <meta name="64er.index_title" content="Marktübersicht: Drucker (Teil 1)">
     <meta name="64er.index_category" content="Hardware|Drucker">
@@ -32,7 +34,9 @@
 
         <p>Ein wichtiger Punkt bei der Auswahl des Druckers ist der Zeichensatz. Nur Drucker, bei denen in der Rubrik »Zeichensatz« der Vermerk »Commodore« vorkommt, können tatsächlich ohne Schwierigkeiten den gesamten Commodore-Zeichensatz drucken. Geräte mit dem Vermerk »ASCII« können ebenso wie Typenraddrucker nur die Standard ASCII-Zeichen drucken, also keine Grafiksymbole oder Steuerzeichen. Ist der Drucker grafikfähig oder können Zeichen selbst definiert werden, dann lassen sich allerdings auch diese speziellen Zeichen per Software simulieren.</p>
 
-        <p>Zum Schluß sei noch gesagt, daß alle Preisangaben nur ungefähre Werte sind. Wer sich bei verschiedenen Anbietern informiert, kann unter Umständen günstiger einkaufen. (ev)</p>
+        <p>Zum Schluß sei noch gesagt, daß alle Preisangaben nur ungefähre Werte sind. Wer sich bei verschiedenen Anbietern informiert, kann unter Umständen günstiger einkaufen.</p>
+
+        <address class="author">(ev)</address>
 
         <p class="literatur"><b>Anbieter-Liste Drucker &amp; Plotter</b><br>Die hier aufgeführten Adressen sind vielfach keine direkten Bezugsquellen. Sie erhalten aber zumindest Datenblatt und Händlernachweis für den von Ihnen ins Auge gefaßten Drucker oder Plotter.</p>
 

--- a/issues/8410/32 So sieht der Output aus.html
+++ b/issues/8410/32 So sieht der Output aus.html
@@ -5,9 +5,9 @@
     <title>So sieht der Output aus</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="32">
+    <meta name="64er.head1" content="Hardware-Test">
     <meta name="64er.toc_category" content="Hardware-Test">
     <meta name="64er.id" content="output">
 </head>

--- a/issues/8410/34 The Blade of Blackpoole – die Lösung.html
+++ b/issues/8410/34 The Blade of Blackpoole – die Lösung.html
@@ -5,9 +5,11 @@
     <title>The Blade of Blackpoole – die Lösung</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Arnd Wängler, aa">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="34-36">
+    <meta name="64er.head1" content="Spiele-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">
     <meta name="64er.index_title" content="Lösung von The Blade of Blackpool">
     <meta name="64er.index_category" content="Spiele-Test|Abenteuer">

--- a/issues/8410/37 Fire-Galaxy.html
+++ b/issues/8410/37 Fire-Galaxy.html
@@ -5,10 +5,10 @@
     <title>Fire-Galaxy</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="C. Q. Spitzner, B. Carti, ev">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="37">
-    <meta name="64er.toc_category" content=Spiele-TestXXX">
+    <meta name="64er.toc_category" content="Spiele-Test">
     <meta name="64er.index_title" content="Fire Galaxy (VC 20)">
     <meta name="64er.index_category" content="Spiele-Test|Arcade">
     <meta name="64er.id" content="fire_galaxy">

--- a/issues/8410/37 House of Usher.html
+++ b/issues/8410/37 House of Usher.html
@@ -5,7 +5,7 @@
     <title>House of Usher</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Manfred Kohlen, aa">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="37">
     <meta name="64er.toc_category" content="Spiele-Test">

--- a/issues/8410/38 Druckfehlerteufelchen.html
+++ b/issues/8410/38 Druckfehlerteufelchen.html
@@ -5,7 +5,6 @@
     <title>Druckfehlerteufelchen</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="38">
     <meta name="64er.toc_category" content="Rubriken">

--- a/issues/8410/43 Der Commodore 64 wird zum PC – mit Vizawrite 64.html
+++ b/issues/8410/43 Der Commodore 64 wird zum PC – mit Vizawrite 64.html
@@ -5,9 +5,11 @@
     <title>Der Commodore 64 wird zum PC – mit Vizawrite 64</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Arnd Wängler, aa">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="43-46">
+    <meta name="64er.head1" content="Software-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Software-Test">
     <meta name="64er.index_title" content="Vizawrite 64 — Der C 64 wird zum PC">
     <meta name="64er.index_category" content="Software-Test|Textverarbeitung">

--- a/issues/8410/46 Lohnsteuerjahresausgleich leichtgemacht.html
+++ b/issues/8410/46 Lohnsteuerjahresausgleich leichtgemacht.html
@@ -5,9 +5,11 @@
     <title>Lohnsteuerjahresausgleich leichtgemacht</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="rg">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="46">
+    <meta name="64er.head1" content="Software-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Software-Test">
     <meta name="64er.index_title" content="Lohnsteuerjahresausgleich leicht gemacht">
     <meta name="64er.index_category" content="Software-Test|Finanzen">
@@ -34,7 +36,9 @@
 
         <h2>Fazit</h2>
 
-        <p>Über die Zweckmäßigkeit dieses Programms kann man geteilter Meinung sein. Solange es nur als Hilfestellung zum Ausfüllen des Jahresausgleichs benutzt wird, ist der Preis von 98 Mark sicherlich nicht zu hoch (man kann auch diesen Kaufpreis unter »Steuerberatungskosten« absetzen). Erwartet man allerdings ein Programm, das den eventuell nötigen Gang zum Steuerberater ersetzt, wird man enttäuscht. Weder Handbuch noch Programm geben konkrete Hinweise über Absetzbarkeit mancher Kosten. Man sollte also möglichst genau wissen, was und wieviel man in dem Antrag an Kosten ansetzen muß. In diesen Fällen wird das Programm wirklich voll ausgenutzt. Allerdings können die Berliner damit recht wenig anfangen. Die Berlinvergünstigung ist nicht berücksichtigt. Vor Änderungen der Steuergesetzgebung braucht man keine Angst zu haben. Das Programm wird, wie der Hersteller mitteilt, bei Änderungen aktualisiert und bei Einsendung einer Originaldiskette ausgetauscht, (rg)</p>
+        <p>Über die Zweckmäßigkeit dieses Programms kann man geteilter Meinung sein. Solange es nur als Hilfestellung zum Ausfüllen des Jahresausgleichs benutzt wird, ist der Preis von 98 Mark sicherlich nicht zu hoch (man kann auch diesen Kaufpreis unter »Steuerberatungskosten« absetzen). Erwartet man allerdings ein Programm, das den eventuell nötigen Gang zum Steuerberater ersetzt, wird man enttäuscht. Weder Handbuch noch Programm geben konkrete Hinweise über Absetzbarkeit mancher Kosten. Man sollte also möglichst genau wissen, was und wieviel man in dem Antrag an Kosten ansetzen muß. In diesen Fällen wird das Programm wirklich voll ausgenutzt. Allerdings können die Berliner damit recht wenig anfangen. Die Berlinvergünstigung ist nicht berücksichtigt. Vor Änderungen der Steuergesetzgebung braucht man keine Angst zu haben. Das Programm wird, wie der Hersteller mitteilt, bei Änderungen aktualisiert und bei Einsendung einer Originaldiskette ausgetauscht.</p>
+
+        <address class="author">(rg)</address>
 
         <p class="literatur">Bezugsquelle: HL Computer-Software GmbH, Hammstr. 8, 6842 Bürstadt, Tel. 0 62 06/8198</p>
 

--- a/issues/8410/48 Ex-DOS – der Disketten-Doktor.html
+++ b/issues/8410/48 Ex-DOS – der Disketten-Doktor.html
@@ -5,9 +5,11 @@
     <title>Ex-DOS – der Disketten-Doktor</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="M. Kohlen, gk">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="48-49">
+    <meta name="64er.head1" content="Software-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Software-Test">
     <meta name="64er.index_title" content="Ex-DOS und Disk Doctor">
     <meta name="64er.index_category" content="Software-Test|Floppy">

--- a/issues/8410/50 Forth ohne Floppy.html
+++ b/issues/8410/50 Forth ohne Floppy.html
@@ -5,9 +5,11 @@
     <title>Forth ohne Floppy</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Daniel Kobler, ev">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="50">
+    <meta name="64er.head1" content="Software-Test">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Software-Test">
     <meta name="64er.index_title" content="Forth ohne Floppy (C 64 und VC 20)">
     <meta name="64er.index_category" content="Software-Test|Sprachen">

--- a/issues/8410/54 So macht man Basic-Programme schneller.html
+++ b/issues/8410/54 So macht man Basic-Programme schneller.html
@@ -5,9 +5,11 @@
     <title>So macht man Basic-Programme schneller</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Dr. Helmuth Hauck, aa">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="54-58">
+    <meta name="64er.head1" content="Software">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Software">
     <meta name="64er.id" content="basic">
 </head>

--- a/issues/8410/59 Datex-P und ausländische Netzwerke.html
+++ b/issues/8410/59 Datex-P und ausländische Netzwerke.html
@@ -5,9 +5,11 @@
     <title>Datex-P und ausländische Netzwerke</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Thomas Obermair, aa">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="59-62">
+    <meta name="64er.head1" content="Software">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Software">
     <meta name="64er.index_title" content="Datex-P und ausländische Netzwerke">
     <meta name="64er.index_category" content="Aktuell|DFÜ">

--- a/issues/8410/65 Bücher.html
+++ b/issues/8410/65 Bücher.html
@@ -5,7 +5,7 @@
     <title>Bücher</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Reinhard Schrutzki, Wolfgang Willing">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="65">
     <meta name="64er.toc_category" content="Rubriken">

--- a/issues/8410/67 HYPRA-LOAD- Schnelles Laden von Diskette.html
+++ b/issues/8410/67 HYPRA-LOAD- Schnelles Laden von Diskette.html
@@ -5,9 +5,11 @@
     <title>HYPRA-LOAD: Schnelles Laden von Diskette</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="K. Schramm, B. Schneider, gk">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="67,77-79">
+    <meta name="64er.head1" content="Listing des Monats">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Listing des Monats">
     <meta name="64er.index_title" content="Hypra-Load: Schnelles Laden von Diskette (LdM)">
     <meta name="64er.index_category" content="Listings zum Abtippen|Anwendung|Floppy">

--- a/issues/8410/68 Menügesteuerte Finanzmathematik.html
+++ b/issues/8410/68 Menügesteuerte Finanzmathematik.html
@@ -5,9 +5,11 @@
     <title>Menügesteuerte Finanzmathematik</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Klaus Klöker">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="68-77">
+    <meta name="64er.head1" content="Anwendung des Monats">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Anwendung des Monats">
     <meta name="64er.index_title" content="Menügesteuerte Finanzmathematik (AdM)">
     <meta name="64er.index_category" content="Listings zum Abtippen|Anwendung|Finanzen">

--- a/issues/8410/8 Aktuelles aus der Datenfernübertragung.html
+++ b/issues/8410/8 Aktuelles aus der Datenfernübertragung.html
@@ -5,7 +5,7 @@
     <title>Aktuelles aus der Datenfernübertragung</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Thomas Obermair, aa">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="8">
     <meta name="64er.toc_category" content="Aktuell">

--- a/issues/8410/8 Drucker oder Plotter.html
+++ b/issues/8410/8 Drucker oder Plotter.html
@@ -5,7 +5,7 @@
     <title>Drucker oder Plotter?</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Michael Pauly, Chefredakteur">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="8">
 	<meta name="64er.toc_category" content="">

--- a/issues/8410/8 SX 64 ausgezeichnet.html
+++ b/issues/8410/8 SX 64 ausgezeichnet.html
@@ -5,7 +5,7 @@
     <title>SX 64 ausgezeichnet</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="aa">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="8-9">
     <meta name="64er.toc_category" content="Aktuell">

--- a/issues/8410/80 Video-Vorspann mit dem VC 20.html
+++ b/issues/8410/80 Video-Vorspann mit dem VC 20.html
@@ -5,9 +5,11 @@
     <title>Video-Vorspann mit dem VC 20</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Wolfgang Schulz, ev">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="80-81">
+    <meta name="64er.head1" content="Anwendung">
+    <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Anwendungen">
     <meta name="64er.index_title" content="Video-Vorspann mit dem VC 20">
     <meta name="64er.index_category" content="Listings zum Abtippen|Anwendung|Video">

--- a/issues/8410/82 Hardcopy MPS 801:VC 1515.html
+++ b/issues/8410/82 Hardcopy MPS 801:VC 1515.html
@@ -5,9 +5,11 @@
     <title>Hardcopy MPS 801/VC 1515</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Rainer Kracht, rg">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="82">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
     <meta name="64er.index_title" content="Hardcopy MPS 801/VC 1515">
     <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|Hardcopy">

--- a/issues/8410/83 Der VC 1526:MPS 802 als Grafikdrucker.html
+++ b/issues/8410/83 Der VC 1526:MPS 802 als Grafikdrucker.html
@@ -5,9 +5,11 @@
     <title>Der VC 1526/MPS 802 als Grafikdrucker</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Lucas Kalt, rg">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="83">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
     <meta name="64er.index_title" content="Der VC 1525/MPS 802 als Grafikdrucker">
     <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|Hardcopy">

--- a/issues/8410/84 Der besondere Leckerbissen — die mehrfarbige Hardcopy.html
+++ b/issues/8410/84 Der besondere Leckerbissen — die mehrfarbige Hardcopy.html
@@ -5,9 +5,11 @@
     <title>Der besondere Leckerbissen — die mehrfarbige Hardcopy</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Klaus Schneider, rg">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="84-85">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
     <meta name="64er.index_title" content="Die mehrfarbige Hardcopy mit dem 1520-Plotter">
     <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|Hardcopy">
@@ -20,7 +22,9 @@
 
         <p class="intro">Mit Ihrem Commodore 64 und einem VC 1520-Plotter können Sie farbige Hardcopys produzieren.</p>
 
-        <p>Das Programm arbeitet als Basic-Lader mit Maschinencodeteil in Form von DATA-Zeilen. Der Maschinenspracheteil operiert im Bereich ab $ 6000, der meines Wissens bei allen gängigen Basic-Versionen zur Verfügung steht. Das bedeutet, daß das Programm mit ihnen lauffähig ist und Hardcopys ihrer Grafikseiten machen kann, selbst wenn diese, wie bei Simons Basic, unter dem ROM liegen. Man braucht nur die Startadresse der Grafikseite einzugeben, und schon setzt sich der Plotter in Bewegung. Die Kopierdauer liegt bei zirka 12 bis 13 Minuten für eine einfarbige Kopie und bei einer halben bis dreiviertel Stunde für eine mehrfarbige Kopie. Dabei gilt: je geringer die Bildgröße, desto schneller die Kopie. Aber auch eine große Grafik wird dann schnell ausgedruckt, wenn sie wenig unterbrochene Linien enthält. (Klaus Schneider/rg)</p>
+        <p>Das Programm arbeitet als Basic-Lader mit Maschinencodeteil in Form von DATA-Zeilen. Der Maschinenspracheteil operiert im Bereich ab $ 6000, der meines Wissens bei allen gängigen Basic-Versionen zur Verfügung steht. Das bedeutet, daß das Programm mit ihnen lauffähig ist und Hardcopys ihrer Grafikseiten machen kann, selbst wenn diese, wie bei Simons Basic, unter dem ROM liegen. Man braucht nur die Startadresse der Grafikseite einzugeben, und schon setzt sich der Plotter in Bewegung. Die Kopierdauer liegt bei zirka 12 bis 13 Minuten für eine einfarbige Kopie und bei einer halben bis dreiviertel Stunde für eine mehrfarbige Kopie. Dabei gilt: je geringer die Bildgröße, desto schneller die Kopie. Aber auch eine große Grafik wird dann schnell ausgedruckt, wenn sie wenig unterbrochene Linien enthält.</p>
+
+        <address class="author">(Klaus Schneider/rg)</address>
 
         <figure>
             <pre data-filename="hc 1520 farbig" data-name="Farbige Hardcopy VC 1520 (Basic-Lader)"></pre>

--- a/issues/8410/85 Hardcopy Gemini-10X.html
+++ b/issues/8410/85 Hardcopy Gemini-10X.html
@@ -5,9 +5,11 @@
     <title>Hardcopy Gemini-10X</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Gunnar E. Krüger, rg">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="85">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
     <meta name="64er.index_title" content="Hardcopy Gemini-10X">
     <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|Hardcopy">

--- a/issues/8410/86 Olympia Compact 2- ein Interface.html
+++ b/issues/8410/86 Olympia Compact 2- ein Interface.html
@@ -5,9 +5,11 @@
     <title>Olympia Compact 2: ein Interface</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Reinhard Atzbach, rg">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="86-88">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
     <meta name="64er.index_title" content="Olympia compact 2: ein Centronics-Interface">
     <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|Schnittstellen">

--- a/issues/8410/88 Hardcopy Epson FX-80.html
+++ b/issues/8410/88 Hardcopy Epson FX-80.html
@@ -5,9 +5,11 @@
     <title>Hardcopy Epson FX-80</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Mark Zimmermann, rg">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="88">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
     <meta name="64er.index_title" content="Hardcopy Epson FX-80">
     <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|Hardcopy">

--- a/issues/8410/89 Tips & Tricks.html
+++ b/issues/8410/89 Tips & Tricks.html
@@ -5,9 +5,11 @@
     <title>Tips &amp; Tricks</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Thomas Lopatic, Oliver Bausch, Jörg Prante, H. Rendelmann, Thomas Maul">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="89-90">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.index_title" content="Diverse">
     <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Tips & Tricks">

--- a/issues/8410/90 Der große Überblick.html
+++ b/issues/8410/90 Der große Überblick.html
@@ -5,9 +5,11 @@
     <title>Der große Überblick</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Michael Weidlich, rg">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="90">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.index_title" content="Der große Überblick: formatiertes Listing">
     <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Listing">

--- a/issues/8410/91 Kudiplo auch für den C 64.html
+++ b/issues/8410/91 Kudiplo auch für den C 64.html
@@ -5,9 +5,11 @@
     <title>Kudiplo auch für den C 64</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Jürgen Curdt, ev">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="91">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.index_title" content="Kudiplo auf für den C 64 (Kurvendiskussion)">
     <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Funktionen">

--- a/issues/8410/91 POKE mal wieder.html
+++ b/issues/8410/91 POKE mal wieder.html
@@ -5,9 +5,11 @@
     <title>POKE mal wieder</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="M. Kohlen, gk">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="91-92">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.index_title" content="POKE mal wieder: diverse POKEs">
     <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|POKEs">
@@ -19,6 +21,8 @@
         <h1>POKE mal wieder</h1>
 
         <p class="intro">Viele C 64-Benutzer haben sich sicher schon mit dem Basic des C 64 herumgeärgert: Egal, was man machen will, fast alles läuft über PEEK und POKE. Doch gerade diese POKEs helfen manchmal erheblich, wenn es um Probleme geht, die mit einfachen Basic-Befehlen nicht zu lösen sind.</p>
+
+        <p>Hier nun eine Liste von wichtigen PEEKs, POKEs und SYS-Befehlen.</p>
 
         <table border="1">
             <tbody>
@@ -174,7 +178,9 @@
             </tbody>
         </table>
 
+        <p>Auf PEEKs und POKEs für Grafik und Sprites wurde hier verzichtet, da die Grafik und die Sprites im Grafikkurs von H. Ponnath schon sehr ausführlich beschrieben sind.</p>
 
+        <address class="author">(M. Kohlen/gk)</address>
     </article>
 
 </body>

--- a/issues/8410/93 User-Port-Tastatur.html
+++ b/issues/8410/93 User-Port-Tastatur.html
@@ -5,9 +5,11 @@
     <title>User-Port-Tastatur</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Martin Kloss, aa">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="93-94">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.index_title" content="User-Port-Tastatur (Zehnertastatur)">
     <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Tastatur">

--- a/issues/8410/95 Diskette intern.html
+++ b/issues/8410/95 Diskette intern.html
@@ -5,9 +5,11 @@
     <title>Diskette intern</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Horst Wibbing, rg">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="95-97">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.index_title" content="Diskette intem (Disk-Dump)">
     <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Floppy">

--- a/issues/8410/97 Disketten-Organisation.html
+++ b/issues/8410/97 Disketten-Organisation.html
@@ -5,9 +5,11 @@
     <title>Disketten-Organisation</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Wilhelm Boosz, ev">
     <meta name="64er.issue" content="10/84">
     <meta name="64er.pages" content="97-100">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.index_title" content="Disketten-Organisation (VC 20)">
     <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Floppy">


### PR DESCRIPTION
I renamed `9 SX 64 ausgezeichnet.html` to `8 SX 64 ausgezeichnet.html` because it starts on page 8.