### PR TITLE
More index fixes

### DIFF
--- a/Jahresinhaltsverzeichnis 1984-85.csv
+++ b/Jahresinhaltsverzeichnis 1984-85.csv
@@ -286,18 +286,18 @@
 8411,73,Listings zum Abtippen|Grafik,Auflösung,Supergrafik II (VC 20)
 8411,74,Listings zum Abtippen|Grafik,Sprites,Sprites ohne Esoterik
 8411,76,Listings zum Abtippen|Grafik,Sprites,Pseudo-Sprites auf dem VC 20
-8411,80,Listings zum Abtippen|Tips & Tricks,Simons Basic,Befehlserweiterung für Simons Basic
 8411,81,Listings zum Abtippen|Tips & Tricks,Hex-Data,Hex-DATA-Automat
 8411,82,Listings zum Abtippen|Tips & Tricks,Generator,Dem Springvogel auf die Sprünge geholfen
 8411,83,Listings zum Abtippen|Tips & Tricks,Joystick,Joystick-Abfrage in Theorie und Praxis
 8411,84,Listings zum Abtippen|Tips & Tricks,Interrupt,Unterbrechen Sie mich bitte!
 8411,88,Listings zum Abtippen|Tips & Tricks,Erweiterung,Betriebssystem-Erweiterung für den VC 20
+8411,90,Listings zum Abtippen|Tips & Tricks,Simons Basic,Befehlserweiterung für Simons Basic
 8411,92,Listings zum Abtippen|Tips & Tricks,Absturz,Die Ebenen des Absturzes
 8411,117,Kurse,Floppy,In die Geheimnisse der Floppy eingetaucht (Teil 2)
 8411,121,Kurse,Assembler,Assembler ist keine Alchimie (Teil 3)
 8411,126,Kurse,VC 20,Der gläserne VC 20 (Teil 3)
 8411,133,Kurse,Speicher,Memory Map mit Wandervorschlägen (Teil 1)
-8411,144,So machen’s andere,Fotografie,Mode-Fotos mit Bits und Bytes
+8411,142,So machen’s andere,Fotografie,Mode-Fotos mit Bits und Bytes
 8411,154,Wettbewerbe,Unterprogramm,Exsort — Sortieren mit Komfort
 8411,158,Wettbewerbe,Einzeiler,Die Top 10 (Einzeiler)
 8412,10,Aktuell,DFÜ,Interessant bis brisant — die elektronischen Briefkästen
@@ -369,6 +369,7 @@
 8501,156,Wettbewerbe,Unterprogramm,Formatierte Eingabe
 8501,157,Wettbewerbe,Einzeiler,Einzeiler-Wettbewerb: Die nächsten 14
 8501,127,Kurse,Speicher,Memory Map mit Wandervorschlägen (Teil 3)
+8502,8,Aktuell,DFÜ,MCI Mail: die schnelle Post
 8502,14,Hardware-Test,Computer,Plus und Minus beim Plus/4
 8502,19,Hardware-Test,Sprachausgabe,Die Stimme des Meisters: Voice Master
 8502,20,Hardware,Bauanleitung,16-KByte-Erweiterung umschaltbar (VC 20)
@@ -406,7 +407,6 @@
 8502,150,Kurse,Speicher,Memory Map mit Wandervorschlägen (Teil 4)
 8502,152,Kurse,Musik,Dem Klang auf der Spur (Teil 3)
 8502,156,Listings zum Abtippen|Spiel,Wettbewerb,Notlandung
-2/88,8,Aktuell,DFÜ,MCI Mail: die schnelle Post
 8503,8,Aktuell,Computer,"Heiße Messe in der Wüste: CES (PC 128, PC 10, Commodore LCD)"
 8503,14,Aktuell,Floppy,Neues 1451-Laufwerk
 8503,15,Aktuell,DFÜ,Internationaler Chaos Communiction Congress


### PR DESCRIPTION
"Befehlserweiterung für Simons Basic" is a real OCR issue, while "Mode-Fotos mit Bits und Bytes" is page 144 in the printed index (page 142 is correct), but I think it doesn't make sense to replicate this error in our own metadata file.