### PR TITLE
Update 20 Mehr Übersicht am Bildschirm – Test 40:80-Zeichenkarte.html

### DIFF
--- a/issues/8410/20 Mehr Übersicht am Bildschirm – Test 40:80-Zeichenkarte.html
+++ b/issues/8410/20 Mehr Übersicht am Bildschirm – Test 40:80-Zeichenkarte.html
@@ -27,7 +27,7 @@
             <figcaption>Bild 1. Die MR 40/80-Karte macht aus dem VC 20 ein professionelles Gerät</figcaption>
         </figure>
 
-        <p>Um 40 oder 80 Zeichen pro Zeile mit dem VC 20 zu realisieren, is auch Software-Lösung möglich. Sie ist jedoch sehr aufwendig, da neben dem Zeichensatz auch weite Teile des Betriebssystems geändert werden müssen. Außerdem ist diese Lösung sehr langsam und nicht für professionelle Anwendungen geeignet.</p>
+        <p>Um 40 oder 80 Zeichen pro Zeile mit dem VC 20 zu realisieren, ist auch eine Software-Lösung möglich. Sie ist jedoch sehr aufwendig, da neben dem Zeichensatz auch weite Teile des Betriebssystems geändert werden müssen. Außerdem ist diese Lösung sehr langsam und nicht für professionelle Anwendungen geeignet.</p>
 
         <p>Eine Hardware-Lösung ist dagegen leichter zu handhaben (nur Karte einstecken) und bietet zusätzliche Leistungen. Wir haben die 40/80-Zeichenkarte MR 40/80 (Bild 1) <a href="#fehlerteufelchen" class="fehlerteufelchen_link">von Roos-Elektronik</a> getestet.</p>
 
@@ -92,7 +92,7 @@
 
         <p>Zu beachten ist die Lage des Bildschirmspeichers. Die MR 40/80 enthält ein eigenes Video-RAM von 2 KByte Umfang, das ab Speicheradresse 43008 ($A800) liegt. Da der normale Video-Speicher nicht benötigt wird, stehen zusätzliche 512 Bytes RAM zur Verfügung. Mit SYS 43000 wird dieser Speicher dem Basic-RAM hinzugefügt.</p>
 
-        <p>Für viele Programme ist es durchaus sinnvoll, die oberste Zeile des Bildschirms zu schützen. Die Zeile bleibt dann unverändert stehen und scrollt auch nicht aus dem ..Bildschirm heraus. So bleiben Überschriften oder Bedienungshilfen ständig sichtbar.</p>
+        <p>Für viele Programme ist es durchaus sinnvoll, die oberste Zeile des Bildschirms zu schützen. Die Zeile bleibt dann unverändert stehen und scrollt auch nicht aus dem Bildschirm heraus. So bleiben Überschriften oder Bedienungshilfen ständig sichtbar.</p>
 
         <p>Die MR 40/80-Karte ist recht übersichtlich aufgebaut und mit einem Video-Controller, einem 2 KByte-CMOS-RAM sowie mit zwei EPROMs (2716 und 2732) und diversen Logikbausteinen bestückt. Alle IC sind gesockelt (!) und können im Schadensfall leicht selbst ausgewechselt werden. Die Steuersoftware im 2716-EPROM belegt den Adreßbereich von $A000 bis $A7FF. Im 2732-EPROM befindet sich der</p>
 


### PR DESCRIPTION
OCR: Letter missing, word missing.
OCR: Two dots from "Ü" as dots "." detected.