### PR TITLE
8411: tags and fixes

### DIFF
--- a/issues/8411/10 Commodore Fachausstellung.html
+++ b/issues/8411/10 Commodore Fachausstellung.html
@@ -5,10 +5,13 @@
     <title>Commodore Fachausstellung</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="aa, gk, rg, M. Kohlen">
     <meta name="64er.issue" content="11/84">
     <meta name="64er.pages" content="10-12">
     <meta name="64er.toc_category" content="Aktuell">
+    <meta name="64er.toc_title" content="Commodore Fachaustellung in Frankfurt">
+    <meta name="64er.index_title" content="Commodore Fachaustellung in Frankfurt">
+    <meta name="64er.index_category" content="Aktuell|Messen">
     <meta name="64er.id" content="fachausstellung">
 </head>
 

--- a/issues/8411/117 In die Geheimnisse der Floppy eingetaucht.html
+++ b/issues/8411/117 In die Geheimnisse der Floppy eingetaucht.html
@@ -2,20 +2,23 @@
 <html lang="de">
 
 <head>
-    <title>In die Geheimnisse der Floppy eingetaucht</title>
+    <title>In die Geheimnisse der Floppy eingetaucht (Teil 2)</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Schramm, Schneider, gk">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="117-118,120,163">
+    <meta name="64er.head1" content="Floppy-Kurs">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Kurse">
+    <meta name="64er.index_category" content="Kurse|Floppy">
     <meta name="64er.id" content="floppy">
 </head>
 
 <body>
     <article>
 
-        <h1>In die Geheimnisse der Floppy eingetaucht</h1>
+        <h1>In die Geheimnisse der Floppy eingetaucht (Teil 2)</h1>
 
         <p class="intro">Diese Folge befaßt sich mit dem Befehlssatz der VC 1541 und deren Meldungen an den Computer. Sie werden erkennen, daß Sie neben Ihrem C 64 noch einen anderen vollständigen Computer vor sich haben, der nicht nur als einfaches und »dummes« Peripheriegerät verstanden werden will.</p>
 

--- a/issues/8411/121 Assembler ist keine Alchimie – Teil 3.html
+++ b/issues/8411/121 Assembler ist keine Alchimie – Teil 3.html
@@ -5,10 +5,14 @@
     <title>Assembler ist keine Alchimie – Teil 3</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Heimo Ponnath, gk">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="121-125">
+    <meta name="64er.head1" content="Assembler-Kurs">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Kurse">
+    <meta name="64er.toc_title" content="Assembler ist keine Alchimie (Teil 3)">
+    <meta name="64er.index_category" content="Kurse|Assembler">
     <meta name="64er.id" content="assembler">
 </head>
 

--- a/issues/8411/126 Der gläserne VC 20 – Teil 3.html
+++ b/issues/8411/126 Der gläserne VC 20 – Teil 3.html
@@ -5,10 +5,14 @@
     <title>Der gläserne VC 20 – Teil 3</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Christoph Sauer, ev">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="126-132">
+    <meta name="64er.head1" content="Kurs">
+    <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Kurse">
+    <meta name="64er.toc_title" content="Der gläserne VC 20 (Teil 3)">
+    <meta name="64er.index_category" content="Kurse|VC 20">
     <meta name="64er.id" content="vc20">
 </head>
 

--- a/issues/8411/133 Memory Map mit Wandervorschlägen.html
+++ b/issues/8411/133 Memory Map mit Wandervorschlägen.html
@@ -5,10 +5,15 @@
     <title>Memory Map mit Wandervorschlägen</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Dr. Helmuth Hauck, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="133-137">
+    <meta name="64er.head1" content="Speicherlandkarte">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Kurse">
+    <meta name="64er.toc_title" content="<b>Memory Map mit Wandervorschlägen (Teil 1)<br>alle POKEs im Detail</b>">
+    <meta name="64er.index_title" content="Memory Map mit Wandervorschlägen (Teil 1)">
+    <meta name="64er.index_category" content="Kurse|Speicher">
     <meta name="64er.id" content="memory_map">
 </head>
 

--- a/issues/8411/14 MSD-Super-Disk-Drive.html
+++ b/issues/8411/14 MSD-Super-Disk-Drive.html
@@ -5,10 +5,14 @@
     <title>MSD-Super-Disk-Drive</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="M. Kohlen">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="14-15">
+    <meta name="64er.head1" content="Hardware-Test">
     <meta name="64er.toc_category" content="Hardware">
+    <meta name="64er.toc_title" content="<b>Test: MSD-Super-Disk-Drive</b>">
+    <meta name="64er.index_title" content="MSD-Super-Disk-Drive">
+    <meta name="64er.index_category" content="Hardware-Test|Floppy">
     <meta name="64er.id" content="msd">
 </head>
 

--- a/issues/8411/142 Mode-Fotos – mit Bits und Bytes.html
+++ b/issues/8411/142 Mode-Fotos – mit Bits und Bytes.html
@@ -5,10 +5,14 @@
     <title>Mode-Fotos – mit Bits und Bytes</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Klaus Koch, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="142-144">
+    <meta name="64er.head1" content="So machen’s andere">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="So machen's andere">
+    <meta name="64er.toc_title" content="Mode-Fotos mit Bits und Bytes">
+    <meta name="64er.index_category" content="So machen’s andere|Fotografie">
     <meta name="64er.id" content="mode_fotos">
 </head>
 

--- a/issues/8411/148 64'er Disk-Ecke.html
+++ b/issues/8411/148 64'er Disk-Ecke.html
@@ -5,9 +5,10 @@
     <title>64'er Disk-Ecke</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="148">
+    <meta name="64er.toc_category" content="Rubriken">
+    <meta name="64er.toc_title" content="Leserservice">
     <meta name="64er.id" content="disk_ecke">
 </head>
 

--- a/issues/8411/154 Unterprogrammbibliothek Exsort – Sortieren mit Komfort.html
+++ b/issues/8411/154 Unterprogrammbibliothek Exsort – Sortieren mit Komfort.html
@@ -5,10 +5,15 @@
     <title>Unterprogrammbibliothek Exsort – Sortieren mit Komfort</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Marcus Rickert, gk">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="154-157">
+    <meta name="64er.head1" content="Unterprogramm-Wettbewerb">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Wettbewerbe">
+    <meta name="64er.toc_title" content="Unterprogrammbibliothek: Exsort">
+    <meta name="64er.index_title" content="Exsort — Sortieren mit Komfort">
+    <meta name="64er.index_category" content="Wettbewerbe|Unterprogramm">
     <meta name="64er.id" content="exsort">
 </head>
 
@@ -109,7 +114,7 @@
 
         <p>Da die Erweiterung nur einmal geladen und gestartet werden muß, kann sie bei späteren Starts des Programms übersprungen werden.</p>
 
-        <p>(Marcus Rickert/gk)</p>
+        <address class="author">(Marcus Rickert/gk)</address>
 
         <aside>
             <h2>Sortierter Lebenslauf:</h2>

--- a/issues/8411/158 Einzeiler-Wettbewerb – die Top 10.html
+++ b/issues/8411/158 Einzeiler-Wettbewerb – die Top 10.html
@@ -5,10 +5,14 @@
     <title>Einzeiler-Wettbewerb – die Top 10</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Andreas Gast, Reinhard Abdel-Hamid, Jens Baas, Andreas Carl, Peter Eckart, Markus Eicher, Joachim Günther, Jörg Wegmeyer, Volker Walter">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="158-160">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Wettbewerbe">
+    <meta name="64er.toc_title" content="<b>Die besten Einzeiler</b>">
+    <meta name="64er.index_title" content="Die Top 10 (Einzeiler)">
+    <meta name="64er.index_category" content="Wettbewerbe|Einzeiler">
     <meta name="64er.id" content="einzeiler">
 </head>
 

--- a/issues/8411/16 Monitor kontra Fernseher.html
+++ b/issues/8411/16 Monitor kontra Fernseher.html
@@ -5,10 +5,15 @@
     <title>Monitor kontra Fernseher</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="gk">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="16-18">
+    <meta name="64er.head1" content="Hardware-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Hardware">
+    <meta name="64er.toc_title" content="<b>Vergleich: Monitor kontra Fernseher</b>">
+    <meta name="64er.index_title" content="Monitor kontra Fernseher (Taxan, 1701, Zenith, Sharp, Panasonic)">
+    <meta name="64er.index_category" content="Hardware-Test|Monitore">
     <meta name="64er.id" content="monitor_fernseher">
 </head>
 

--- a/issues/8411/161 Programmierwettbewerb- Das »intelligente« Programm.html
+++ b/issues/8411/161 Programmierwettbewerb- Das »intelligente« Programm.html
@@ -7,8 +7,9 @@
     <link rel="stylesheet" href="../style.css">
     <meta name="author" content="XXX">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="161">
     <meta name="64er.toc_category" content="Wettbewerbe">
+    <meta name="64er.toc_title" content="Das intelligente Programm">
     <meta name="64er.id" content="intelligent">
 </head>
 

--- a/issues/8411/164 Vorschau.html
+++ b/issues/8411/164 Vorschau.html
@@ -5,9 +5,8 @@
     <title>Vorschau</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="164">
     <meta name="64er.toc_category" content="Rubriken">
     <meta name="64er.id" content="vorschau">
 </head>

--- a/issues/8411/19 Marktübersicht Drucker – Teil 2.html
+++ b/issues/8411/19 Marktübersicht Drucker – Teil 2.html
@@ -5,10 +5,15 @@
     <title>Marktübersicht Drucker – Teil 2</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="ev">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="19,21">
+    <meta name="64er.head1" content="Hardware">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Hardware">
+    <meta name="64er.toc_title" content="Marktübersicht Drucker">
+    <meta name="64er.index_title" content="Marktübersicht: Drucker (Teil 2)">
+    <meta name="64er.index_category" content="Hardware|Drucker">
     <meta name="64er.id" content="drucker">
 </head>
 
@@ -26,7 +31,9 @@
 
         <h3>Anbieter-Liste Drucker &amp; Plotter (Teil 2)</h3>
 
-        <p>Die hier aufgeführten Adressen sind in der Regel keine direkten Bezugsquellen. Sie erhalten hier jedoch Datenblatt und Händlernachweis für den von Ihnen ins Auge gefaßten Drucker oder Plotter. (ev)</p>
+        <p>Die hier aufgeführten Adressen sind in der Regel keine direkten Bezugsquellen. Sie erhalten hier jedoch Datenblatt und Händlernachweis für den von Ihnen ins Auge gefaßten Drucker oder Plotter.</p>
+
+        <address class="author">(ev)</address>
 
         <aside>
             <p>Ascalon-Vertrieb Mayon Elektronik GmbH, Postfach 1925, 8034 Germering<br>

--- a/issues/8411/19 Marktübersicht Schwarzweiß- und Farbmonitore.html
+++ b/issues/8411/19 Marktübersicht Schwarzweiß- und Farbmonitore.html
@@ -5,10 +5,15 @@
     <title>Marktübersicht Schwarzweiß- und Farbmonitore</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="ev">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="19-20">
+    <meta name="64er.head1" content="Hardware">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Hardware">
+    <meta name="64er.toc_title" content="<b>Marktübersicht Monitore</b>">
+    <meta name="64er.index_title" content="Marktübersicht: Schwarzweiß- und Farbmonitore">
+    <meta name="64er.index_category" content="Hardware|Monitor">
     <meta name="64er.id" content="monitore">
 </head>
 

--- a/issues/8411/22 Ein starkes Stück.html
+++ b/issues/8411/22 Ein starkes Stück.html
@@ -5,10 +5,15 @@
     <title>Ein starkes Stück</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Arnd Wängler">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="22,161">
+    <meta name="64er.head1" content="Hardware-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Hardware-Test">
+    <meta name="64er.toc_title" content="Ein starkes Stück<br>Itoh 8510 und 1550B">
+    <meta name="64er.index_title" content="Ein starkes Stück (Itoh 8510)">
+    <meta name="64er.index_category" content="Hardware-Test|Drucker">
     <meta name="64er.id" content="itoh_8510">
 </head>
 

--- a/issues/8411/24 Der Petal MA20 – kleiner Name, großer Drucker.html
+++ b/issues/8411/24 Der Petal MA20 – kleiner Name, großer Drucker.html
@@ -5,10 +5,12 @@
     <title>Der Petal MA20 – kleiner Name, großer Drucker</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Arnd Wängler, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="24">
     <meta name="64er.toc_category" content="Hardware-Test">
+    <meta name="64er.index_title" content="Der Petal MA20 — kleiner Name, großer Drucker">
+    <meta name="64er.index_category" content="Hardware-Test|Drucker">
     <meta name="64er.id" content="petal_ma20">
 </head>
 

--- a/issues/8411/26 Drucksympathie.html
+++ b/issues/8411/26 Drucksympathie.html
@@ -5,10 +5,13 @@
     <title>Drucksympathie</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Arnd Wängler, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="26">
     <meta name="64er.toc_category" content="Hardware-Test">
+    <meta name="64er.toc_title" content="Drucksympathie BMC BX100">
+    <meta name="64er.index_title" content="Drucksympathie (BMC BX100)">
+    <meta name="64er.index_category" content="Hardware-Test|Drucker">
     <meta name="64er.id" content="bmc_bx100">
 </head>
 

--- a/issues/8411/30 Wie super ist die Supergrafik.html
+++ b/issues/8411/30 Wie super ist die Supergrafik.html
@@ -5,10 +5,15 @@
     <title>Wie super ist die Supergrafik?</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Boris Schneider, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="30-31,157">
+    <meta name="64er.head1" content="Software-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Software-Test">
+    <meta name="64er.toc_title" content="<b>C 64: Der Grafikgigant<br>Wie Super ist die Supergraphik 64?</b>">
+    <meta name="64er.index_title" content="Wie Super ist die Supergrafik? (Supergrafik 64)">
+    <meta name="64er.index_category" content="Software-Test|Grafik">
     <meta name="64er.id" content="supergraphik">
 </head>
 

--- a/issues/8411/32 Viel zu schade, um nur damit zu kalkulieren.html
+++ b/issues/8411/32 Viel zu schade, um nur damit zu kalkulieren.html
@@ -5,10 +5,15 @@
     <title>Viel zu schade, um nur damit zu kalkulieren</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Klaus Koch, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="32-33">
+    <meta name="64er.head1" content="Software-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Software-Test">
+    <meta name="64er.toc_title" content="Viel zu schade, um nur damit zu kalkulieren: Multiplan 64">
+    <meta name="64er.index_title" content="Multiplan: Viel zu schade, um nur damit zu kalkulieren">
+    <meta name="64er.index_category" content="Software-Test|Tabellenkalkulation">
     <meta name="64er.id" content="multiplan">
 </head>
 

--- a/issues/8411/34 David und Goliath.html
+++ b/issues/8411/34 David und Goliath.html
@@ -5,10 +5,16 @@
     <title>David und Goliath</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Christian Quirin Spitzner, rg">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="34-36">
+    <meta name="64er.head1" content="Grafik-Tabletts">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Software-Test">
+    <meta name="64er.toc_title" content="<b>Zeichenbretter im Test:<br>Koala Pad und Supersketch<br>David und Goliath</b>">
+    <meta name="64er.index_title" content="Grafiktabletts: KoalaPad und SuperSketch">
+    <meta name="64er.index_category" content="Hardware-Test|Grafik">
+    <meta name="64er.index_category" content="Software-Test|Grafik">
     <meta name="64er.id" content="zeichenprogramme">
 </head>
 

--- a/issues/8411/37 Grafik hoch zwei – das Extended Graphik System.html
+++ b/issues/8411/37 Grafik hoch zwei – das Extended Graphik System.html
@@ -5,10 +5,14 @@
     <title>Grafik hoch zwei – das Extended Graphik System</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Arnd Wängler, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="37">
+    <meta name="64er.head1" content="Software-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Software-Test">
+    <meta name="64er.index_title" content="<b>Grafik hoch zwei — das Extended Graphic System</b>">
+    <meta name="64er.index_category" content="Software-Test|Grafik">
     <meta name="64er.id" content="extended_graphik_system">
 </head>
 

--- a/issues/8411/38 Viza Star – Ein Stern wird geboren – der Commodore 64.html
+++ b/issues/8411/38 Viza Star – Ein Stern wird geboren – der Commodore 64.html
@@ -5,10 +5,15 @@
     <title>Viza Star – Ein Stern wird geboren – der Commodore 64</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Arnd Wängler, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="38-41">
+    <meta name="64er.head1" content="Software-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Software-Test">
+    <meta name="64er.toc_title" content="Vizastar<br>Ein Stern wird geboren ...">
+    <meta name="64er.index_title" content="VizaStar — Ein Stern wird geboren">
+    <meta name="64er.index_category" content="Software-Test|Tabellenkalkulation">
     <meta name="64er.id" content="viza_star">
 </head>
 

--- a/issues/8411/42 Exodus – Ultima III.html
+++ b/issues/8411/42 Exodus – Ultima III.html
@@ -5,10 +5,15 @@
     <title>Exodus – Ultima III</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Manfred Kohlen, F. Wlodarczyk, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="42-43">
+    <meta name="64er.head1" content="Spiele-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">
+    <meta name="64er.toc_title" content="Exodus-Ultima III">
+    <meta name="64er.index_title" content="Exodus – Ultima III">
+    <meta name="64er.index_category" content="Spiele-Test|Abenteuer">
     <meta name="64er.id" content="ultima_iii">
 </head>
 
@@ -51,7 +56,7 @@
 
         <p>Exodus ist ein durchaus empfehlenswertes Spiel, das den Spieler auch über längere Zeit hinweg beschäftigen kann (außer er verzweifelt daran) und nicht so schnell langweilig wird.</p>
 
-        <address class="author">(Manfred Kohlen/F.Wlodarczyk/aa)</address>
+        <address class="author">(Manfred Kohlen/F. Wlodarczyk/aa)</address>
 
         <p>PS: Wir werden auch weiterhin über interessante Fantasy- und Abenteuerspiele berichten, sowie Lösungshinweise zu besonders schwierigen Abenteuern bieten. Im Augenblick arbeiten wir an einer Lösung zu Encharter, die wir voraussichtlich in der Februar-Ausgabe veröffentlichen werden.Weitere Lösungsvorschläge zu besonders guten und besonders schwierigen Abenteuerspielen sind jederzeit willkommen.</p>
 

--- a/issues/8411/43 Abenteuer selbst gemacht.html
+++ b/issues/8411/43 Abenteuer selbst gemacht.html
@@ -5,10 +5,15 @@
     <title>Abenteuer selbst gemacht</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="M. Kohlen, F. Wlodarczyk, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="43">
+    <meta name="64er.head1" content="Spiele-Test">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">
+    <meta name="64er.toc_title" content="Adventure Creator">
+    <meta name="64er.index_title" content="Abenteuer selbst gemacht — Adventure Creator">
+    <meta name="64er.index_category" content="Spiele-Test|Abenteuer">
     <meta name="64er.id" content="adventure_creator">
 </head>
 

--- a/issues/8411/44 Comal – eine Einführung – Teil 1.html
+++ b/issues/8411/44 Comal – eine Einführung – Teil 1.html
@@ -5,10 +5,15 @@
     <title>Comal – eine Einführung – Teil 1</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="ev">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="44-47">
+    <meta name="64er.head1" content="Programmiersprachen">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Kurse">
+    <meta name="64er.toc_title" content="<b>Einführung in Comal (Teil 1)</b>">
+    <meta name="64er.index_title" content="Comal — Eine Einführung (Teil 1)">
+    <meta name="64er.index_category" content="Kurse|Comal">
     <meta name="64er.id" content="comal">
 </head>
 

--- a/issues/8411/48 Turtle-Grafik – Die schnelle Schildkröte.html
+++ b/issues/8411/48 Turtle-Grafik – Die schnelle Schildkröte.html
@@ -5,10 +5,15 @@
     <title>Turtle-Grafik – Die schnelle Schildkröte</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Peter Menke, gk">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
-    <meta name="64er.toc_category" content="Wettbewerbe">
+    <meta name="64er.pages" content="48-49,55-59">
+    <meta name="64er.head1" content="Listing des Monats">
+    <meta name="64er.head2" content="C 64">
+    <meta name="64er.toc_category" content="Wettbewerbe"> <!-- |Listing des Monats -->
+    <meta name="64er.toc_title" content="<b>Listing des Monats<br>Zeichnen mit der schnellen Schildkröte:</b><br>Turtle Grafik">
+    <meta name="64er.index_title" content="Turtle-Grafik — Die schnelle Schildkröte (LdM)">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|Turtle-Grafik">
     <meta name="64er.id" content="turtle_grafik">
 </head>
 
@@ -21,7 +26,7 @@
 
         <figure>
             <img src="48-1.png" alt="">
-            <figcaption>ln sekundenschnelle ist dieses Bild aufgebaut</figcaption>
+            <figcaption>In sekundenschnelle ist dieses Bild aufgebaut</figcaption>
         </figure>
         <figure>
             <img src="48-2.png" alt="">

--- a/issues/8411/50 Schachmeister.html
+++ b/issues/8411/50 Schachmeister.html
@@ -5,10 +5,15 @@
     <title>Schachmeister</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Thomas Behrend, rg">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
-    <meta name="64er.toc_category" content="Wettbewerbe">
+    <meta name="64er.pages" content="50-54">
+    <meta name="64er.head1" content="Anwendung des Monats">
+    <meta name="64er.head2" content="C 64">
+    <meta name="64er.toc_category" content="Wettbewerbe"> <!-- |Anwendung des Monats -->
+    <meta name="64er.toc_title" content="<b>Anwendung des Monats</b><br>Schachmeister">
+    <meta name="64er.index_title" content="Schachmeister (AdM)">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Anwendung|Schach">
     <meta name="64er.id" content="schachmeister">
 </head>
 

--- a/issues/8411/60 Ohne gutes Werkzeug geht es nicht- SMON – Teil 1.html
+++ b/issues/8411/60 Ohne gutes Werkzeug geht es nicht- SMON – Teil 1.html
@@ -5,10 +5,15 @@
     <title>Ohne gutes Werkzeug geht es nicht: SMON – Teil 1</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Dietrich Weineck, N. Mann, gk">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="60-65">
+    <meta name="64er.head1" content="Anwendung">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Anwendungen">
+    <meta name="64er.toc_title" content="<b>Maschinenspache besser als gekauft<br>Monitor zum Abtippen:</b> SMON (Teil1)">
+    <meta name="64er.index_title" content="Ohne gutes Werkzeug geht es nicht: SMON (Teil 1)">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Anwendung|Monitor">
     <meta name="64er.id" content="smon">
 </head>
 

--- a/issues/8411/66 Get Koala Pic.html
+++ b/issues/8411/66 Get Koala Pic.html
@@ -5,10 +5,15 @@
     <title>Get Koala Pic</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Vera F. Birkenbihl, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="66-67">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
+    <meta name="64er.toc_title" content="<b>Werkzeuge für Grafikprogrammierer</b><br>Get Koala Pic">
+    <meta name="64er.index_title" content="Get Koala Pic">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|KoalaPad">
     <meta name="64er.id" content="get_koala_pic">
 </head>
 

--- a/issues/8411/68 Der VC 20 als Laterna Magica.html
+++ b/issues/8411/68 Der VC 20 als Laterna Magica.html
@@ -5,10 +5,14 @@
     <title>Der VC 20 als Laterna Magica</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Bernd Schrödter, ev">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="68-70">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
+    <meta name="64er.index_title" content="Der VC 20 als Laterna Magica">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|Trickfilm">
     <meta name="64er.id" content="laterna_magica">
 </head>
 

--- a/issues/8411/70 Grafik leicht gemacht.html
+++ b/issues/8411/70 Grafik leicht gemacht.html
@@ -5,10 +5,14 @@
     <title>Grafik leicht gemacht</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Uwe Seimet, rg">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="70-72">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
+    <meta name="64er.index_title" content="Grafik leicht gemacht">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|Funktionen">
     <meta name="64er.id" content="funktionenplot">
 </head>
 

--- a/issues/8411/73 Druckfehlerteufelchen.html
+++ b/issues/8411/73 Druckfehlerteufelchen.html
@@ -5,10 +5,10 @@
     <title>Druckfehlerteufelchen</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="73">
     <meta name="64er.toc_category" content="Rubriken">
+    <meta name="64er.toc_title" content="Fehlerteufelchen">
     <meta name="64er.id" content="druckfehlerteufelchen">
 </head>
 

--- a/issues/8411/73 Supergrafik II.html
+++ b/issues/8411/73 Supergrafik II.html
@@ -5,10 +5,14 @@
     <title>Supergrafik II</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Rudolf Dörr, ev">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="73">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="VC 20 (GV)">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
+    <meta name="64er.index_title" content="Supergrafik II (VC 20)">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|Auflösung">
     <meta name="64er.id" content="supergrafik_ii">
 </head>
 

--- a/issues/8411/74 Sprites ohne Esoterik.html
+++ b/issues/8411/74 Sprites ohne Esoterik.html
@@ -5,10 +5,13 @@
     <title>Sprites ohne Esoterik</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Pascal Dornier, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="74-75">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|Sprites">
     <meta name="64er.id" content="sprites">
 </head>
 

--- a/issues/8411/76 Pseudo-Sprites auf dem VC 20.html
+++ b/issues/8411/76 Pseudo-Sprites auf dem VC 20.html
@@ -5,10 +5,14 @@
     <title>Pseudo-Sprites auf dem VC 20</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Markus Leberecht, ev">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="76-80">
+    <meta name="64er.head1" content="Grafik">
+    <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Grafik">
+    <meta name="64er.toc_title" content="<b>Pseudo-Sprites auf dem VC 20</b>">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Grafik|Sprites">
     <meta name="64er.id" content="pseudo_sprites">
 </head>
 

--- a/issues/8411/8 Informationen zur Datenfernübertragung.html
+++ b/issues/8411/8 Informationen zur Datenfernübertragung.html
@@ -5,10 +5,11 @@
     <title>Informationen zur Datenfernübertragung</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Thomas Obermair, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="8-9">
     <meta name="64er.toc_category" content="Aktuell">
+    <meta name="64er.toc_title" content="Neues aus der Datenfernübertragung">
     <meta name="64er.id" content="dfü">
 </head>
 
@@ -55,7 +56,9 @@
 
         <p>Rolf Rocke Computer bietet mit dem »Print 64« ein prozessorgesteuertes Drucker-Interface für Anspruchsvolle. Nachahmenswert ist ein auf der mitgelieferten Diskette befindlicher Druckerkurs, der den Umgang mit der Schnittstelle und den gängigsten Matrixdruckern wie Epson, Star oder Sekonic für den Anfänger anschaulich erläutert.</p>
 
-        <p>Außergewöhnlich ist auch die Möglichkeit der Darstellung von Farben (auf Schwarz-Weiß-Druckern) durch geeignete Wahl von zugeordneten Graustufen beim Druck von Mehrfarbgrafiken. Mit fünf unterschiedlichen Tönungen bleiben bei Mehrfarbbildern (die vom Koalapainter oder Paint Magic erstellt sein können) die Nuancen des Bildes in der Hardcopy erhalten. »Print 64» soll alle gängigen Textverarbeitungsprogramme für den C 64 unterstützen. Das heißt, auch Umlaute, Fettschrift oder Unterstreichen werden getreu wiedergegeben. Programmlistings werden mit allen Grafik- und Steuerzeichen in Grafik- oder Groß/Kleinschrift-Modus ausgeben. Der Ausdruck des Bildschirms ist in verschiedenen Varianten möglich. Der Textbildschirm kann in einfacher oder doppelter Dichte ausgegeben werden. Bilder in hochauflösender Grafik benötigen für die Übertragung sowohl in normaler als auch in doppelter Dichte nur zirka 70 Sekunden (FX 80). Durch die Wahl der Bildbreite über das gesamte A4-Format ergibt sich ein Verhältnis von Höhe zu Breite die auch die Darstellung von Kreisen orginalgetreu zuläßt. Die Sekundäradressen 3, 4, 6, 8 und 9 wurden für selbst zu erstellende Hardcopy-Routinen reserviert. Das Centronics-Interface mit der Diskette wird voraussichtlich 300 Mark kosten. (aa)</p>
+        <p>Außergewöhnlich ist auch die Möglichkeit der Darstellung von Farben (auf Schwarz-Weiß-Druckern) durch geeignete Wahl von zugeordneten Graustufen beim Druck von Mehrfarbgrafiken. Mit fünf unterschiedlichen Tönungen bleiben bei Mehrfarbbildern (die vom Koalapainter oder Paint Magic erstellt sein können) die Nuancen des Bildes in der Hardcopy erhalten. »Print 64» soll alle gängigen Textverarbeitungsprogramme für den C 64 unterstützen. Das heißt, auch Umlaute, Fettschrift oder Unterstreichen werden getreu wiedergegeben. Programmlistings werden mit allen Grafik- und Steuerzeichen in Grafik- oder Groß/Kleinschrift-Modus ausgeben. Der Ausdruck des Bildschirms ist in verschiedenen Varianten möglich. Der Textbildschirm kann in einfacher oder doppelter Dichte ausgegeben werden. Bilder in hochauflösender Grafik benötigen für die Übertragung sowohl in normaler als auch in doppelter Dichte nur zirka 70 Sekunden (FX 80). Durch die Wahl der Bildbreite über das gesamte A4-Format ergibt sich ein Verhältnis von Höhe zu Breite die auch die Darstellung von Kreisen orginalgetreu zuläßt. Die Sekundäradressen 3, 4, 6, 8 und 9 wurden für selbst zu erstellende Hardcopy-Routinen reserviert. Das Centronics-Interface mit der Diskette wird voraussichtlich 300 Mark kosten.</p>
+
+        <address class="author">(aa)</address>
 
         <p>Info: Rolf Rocke Computer, Auestraße 1, 5090 Leverkusen 3, Tel.: 0 2171-26 24</p>
 

--- a/issues/8411/8 Zuviel Programme, keine Ideen.html
+++ b/issues/8411/8 Zuviel Programme, keine Ideen.html
@@ -2,12 +2,12 @@
 <html lang="de">
 
 <head>
-    <title>Zuviel Programme, keine Ideen?</title>
+    <title>Editorial: Zuviel Programme, keine Ideen?</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Michael Pauly, Chefredakteur">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="8">
     <meta name="64er.id" content="editorial">
 </head>
 

--- a/issues/8411/81 Hex-DATA-Automat.html
+++ b/issues/8411/81 Hex-DATA-Automat.html
@@ -5,10 +5,13 @@
     <title>Hex-DATA-Automat</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Heino Velder, ev">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="81-82">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Hex-Data">
     <meta name="64er.id" content="hex_data">
 </head>
 

--- a/issues/8411/82 Dem »Springvogel« auf die Sprünge geholfen.html
+++ b/issues/8411/82 Dem »Springvogel« auf die Sprünge geholfen.html
@@ -5,10 +5,15 @@
 	<title>Dem »Springvogel« auf die Sprünge geholfen</title>
 	<meta charset="UTF-8">
 	<link rel="stylesheet" href="../style.css">
-	<meta name="author" content="XXX">
+    <meta name="author" content="Thomas Schmidt, aa">
 	<meta name="64er.issue" content="11/84">
 	<meta name="64er.pages" content="82">
-	<meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
+    <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
+    <meta name="64er.toc_title" content="Spring-Vogel-II">
+    <meta name="64er.index_title" content="Dem Springvogel auf die Sprünge geholfen">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Generator">
 	<meta name="64er.id" content="springvogel">
 </head>
 

--- a/issues/8411/83 Joystick-Abfrage in Theorie und Praxis.html
+++ b/issues/8411/83 Joystick-Abfrage in Theorie und Praxis.html
@@ -5,10 +5,15 @@
     <title>Joystick-Abfrage in Theorie und Praxis</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Helmuth Hauck, rg">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="83">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
+    <meta name="64er.toc_title" content="<b>Joystick-Abfrage</b>">
+    <meta name="64er.index_title" content="Joystick-Abfrage in Theorie und Praxis">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Joystick">
     <meta name="64er.id" content="joystick">
 </head>
 

--- a/issues/8411/84 Unterbrechen Sie mich bitte!.html
+++ b/issues/8411/84 Unterbrechen Sie mich bitte!.html
@@ -5,10 +5,14 @@
     <title>Unterbrechen Sie mich bitte!</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Helmut Welke, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="84-87">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
+    <meta name="64er.toc_title" content="<b>Interrupt-Technik</b>">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Interrupt">
     <meta name="64er.id" content="interrupts">
 </head>
 

--- a/issues/8411/88 Betriebssystem-Erweiterung für den VC 20.html
+++ b/issues/8411/88 Betriebssystem-Erweiterung für den VC 20.html
@@ -5,10 +5,13 @@
     <title>Betriebssystem-Erweiterung für den VC 20</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Manfred Weigt, ev">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="88-89">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="VC 20 + 24 KByte">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Erweiterung">
     <meta name="64er.id" content="erweiterungen">
 </head>
 

--- a/issues/8411/90 Befehlserweiterung für Simons Basic.html
+++ b/issues/8411/90 Befehlserweiterung für Simons Basic.html
@@ -5,10 +5,13 @@
     <title>Befehlserweiterung für Simons Basic</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Dieter Temme, gk">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="90-91">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Simons Basic">
     <meta name="64er.id" content="simons">
 </head>
 

--- a/issues/8411/92 Die Ebenen des Absturzes.html
+++ b/issues/8411/92 Die Ebenen des Absturzes.html
@@ -5,10 +5,14 @@
     <title>Die Ebenen des Absturzes</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="Daniel Kossmann, aa">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="92-93">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
+    <meta name="64er.toc_title" content="<b>Die Ebenen des Absturzes</b>">
+    <meta name="64er.index_category" content="Listings zum Abtippen|Tips & Tricks|Absturz">
     <meta name="64er.id" content="absturz">
 </head>
 

--- a/issues/8411/94 Epedemic 2.html
+++ b/issues/8411/94 Epedemic 2.html
@@ -5,9 +5,11 @@
     <title>Epedemic 2</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="XXX">
+    <meta name="author" content="ev">
     <meta name="64er.issue" content="11/84">
-    <meta name="64er.pages" content="999">
+    <meta name="64er.pages" content="94">
+    <meta name="64er.head1" content="Tips & Tricks">
+    <meta name="64er.head2" content="VC 20 + 8 KByte">
     <meta name="64er.toc_category" content="Programme zum Abtippen|Tips & Tricks">
     <meta name="64er.id" content="epedemic">
 </head>


### PR DESCRIPTION
For 11/84 they used some new design element for the toc. For example they put "Listing des Montags", "Anwendung des Monats" and others under "Wettbewerbe" and have a subheading "Neue Kurse" under "Kurse".

The proper way to handle this would imho be to support subcategories for all toc categories, not only for "Programm zum Abtippen". So the category for the examples above would be "Wettbewerbe|Listing des Monats", "Wettbewerbe|Anwendung des Monats" and "Kurse|Neue Kurse".

As this isn't implemented yet, for now I kludged it by adding `<b>` tags to the `toc_title` tags. And while I was at it, I did the same for other toc entries which are in bold, too, as an experiment. I think there is some value in indicating which articles the original editors considered important. 

Let me know what you think. If you don't like it, no problem, I'll remove them again. Otherwise I'd consider adding them to the already published issues in a similar fashion, too.