### PR TITLE
css additions

### DIFF
--- a/issues/style.css
+++ b/issues/style.css
@@ -232,6 +232,17 @@ p.source {
 	text-indent: unset;
 }
 
+p.noindent {
+	text-indent: unset;
+}
+
+p code {
+	display: block;
+	font-family: "RL", serif;
+	white-space: pre-line;
+	text-indent: 0;
+	margin: 0.2em 0;
+}
 
 pre {
 	font-family: "RL", serif;


### PR DESCRIPTION
I'd suggest to add these two entries to the css. Both should help to avoid the sometimes massive amount of formatting by `<br>` elements we use right now:

- `p.noident` for `<p>` elements should also help with cases like 8411 page 148 "Disk-Ecke", where the content lists aren't really paragraphs so they imo look a bit ugly with the indentation.
- `p code` is for the many cases where little code (or similar) snippets are included in the text, for example like this part from 8411 page 133 "Memory Map mit Wandervorschlägen":

```html
    <p>Dann nämlich können wir zuerst das Interlock-Register mit einem Wert größer als 0 lahmlegen:<br>
    POKE 192,255<br>
    Jetzt läßt sich der Motor der Datasette mit Bit 5 steuern:<br>
    POKE 1,39 beziehungsweise<br>
    POKE 1,PEEK(1) OR 32<br>
    schaltet den Motor aus,<br>
    POKE 1,7 beziehungsweise<br>
    POKE 1,PEEK(1) AND 31<br>
    schaltet den Motor ein.</p>
```

could be changed to

```html
    <p>Dann nämlich können wir zuerst das Interlock-Register mit einem Wert größer als 0 lahmlegen:
    <code>POKE 192,255</code>
    Jetzt läßt sich der Motor der Datasette mit Bit 5 steuern:
    <code>POKE 1,39 beziehungsweise
          POKE 1,PEEK(1) OR 32</code>
    schaltet den Motor aus,
    <code>POKE 1,7 beziehungsweise
          POKE 1,PEEK(1) AND 31</code>
    schaltet den Motor ein.</p>
```

which I find much clearer.

Things to consider:
- Maybe there's a better way which is already supported by the current css which I just haven't found.
- `<code>` is changed from `inline` to `block`, which isn't ideal, but I didn't come up with a better element to use.
- The added vertical margin imo improves readability in the browser, but is less authentic.
- Using a monospace font for the `<code>` would improve readability even more, but also be even less authentic, some I'm not sure that would be a good idea.