### PR TITLE
More css additions

### DIFF
--- a/issues/style.css
+++ b/issues/style.css
@@ -599,6 +599,10 @@ article ul > li:before {
 	padding-right: 0.4em;
 }
 
+article ul.plain > li:before {
+	content: none;
+}
+
 /* Impressum */
 
 article.impressum em {

--- a/issues/style.css
+++ b/issues/style.css
@@ -227,6 +227,10 @@ address.author {
 	text-align: right;
 }
 
+div.q p.author {
+	font-style: normal;
+}
+
 p.source {
 	font-size: small;
 	text-indent: unset;


### PR DESCRIPTION
I started integrating the css changes from #133 into 8411 and find that it would also be useful to have a way to add lists without bullet symbols.

The obvious use case are things like the manufacturer lists in page 19 "Marktübersicht Drucker" and "Marktübersicht Monitore".

But I would also find them useful for the occasional parameter (and other) lists, like this example from page 117 "In die Geheimnisse der Floppy eingetaucht":

```html
<li>Der BLOCK-READ-Befehl (B-R):<br>
    Mit dem BLOCK-READ-Befehl liest man jeden beliebigen Block von Diskette in einen vorher reservierten Puffer. Die Syntax lautet:<br>
    PRINT#fn,"B-R";kn;dn;t;s<br>
    dn — Drivenummer (immer 0)<br>
    t — Tracknummer<br>
    s — Sektornummer<br>
    Beispiel: PRINT#15,"B-R 2 0 18 0”
</li>
```

where the description for `dn`, `t`, `s` could become a list:

```html
<ul class="plain">
    <li>dn — Drivenummer (immer 0)</li>
    <li>t — Tracknummer</li>
    <li>s — Sektornummer</li>
</ul>
```

This is visually identical to the original version, but both avoids the formatting by `<br>` and also provides context that this is actually a list of some sort, which I imagine would e.g. be useful information for screen readers (not expert, though).

The second commit is only for discussion, I just wonder what you think: I noticed that author names in "Leserforum" are italic if they appear inside a `<div class="q">` element, and non-italic if they are part of a non-question submission.

I like that the questions are in both bold and italic, it's just that I find the names in italic look a bit odd next to the non-italic names, but maybe that's just me. I have no strong feelings either way, I just like to point it out.

(The names also are in bold type only in the first case, but I think that's ok).