### PR TITLE
Prebuild search index

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -15,6 +15,7 @@ import hashlib
 import urllib.parse
 import pytz
 import argparse
+import gzip
 import lunr
 from dataclasses import dataclass, field
 from collections import defaultdict, OrderedDict
@@ -1785,6 +1786,8 @@ def generate_search_json(db, out_directory):
     # Save the array as JSON
     with open(os.path.join(out_directory, 'search.json'), 'w', encoding='utf-8') as f:
         json.dump(articles_info, f, ensure_ascii=False, indent=4)
+    with gzip.open(os.path.join(out_directory, 'search.json.gz'), 'wt') as f:
+        json.dump(articles_info, f, ensure_ascii=False, indent=4)
 
     idx = lunr.lunr(
         ref='href',
@@ -1793,6 +1796,8 @@ def generate_search_json(db, out_directory):
     )
     serialized_idx = idx.serialize()
     with open(os.path.join(out_directory, 'search_idx.json'), 'w', encoding='utf-8') as f:
+        json.dump(serialized_idx, f, ensure_ascii=False)
+    with gzip.open(os.path.join(out_directory, 'search_idx.json.gz'), 'wt') as f:
         json.dump(serialized_idx, f, ensure_ascii=False)
 
 def generate_author_pages(db, out_directory):

--- a/generate.py
+++ b/generate.py
@@ -15,6 +15,7 @@ import hashlib
 import urllib.parse
 import pytz
 import argparse
+import lunr
 from dataclasses import dataclass, field
 from collections import defaultdict, OrderedDict
 from bs4 import BeautifulSoup, NavigableString
@@ -1784,6 +1785,15 @@ def generate_search_json(db, out_directory):
     # Save the array as JSON
     with open(os.path.join(out_directory, 'search.json'), 'w', encoding='utf-8') as f:
         json.dump(articles_info, f, ensure_ascii=False, indent=4)
+
+    idx = lunr.lunr(
+        ref='href',
+        fields=['title', 'categories', 'content'],
+        documents=articles_info,
+    )
+    serialized_idx = idx.serialize()
+    with open(os.path.join(out_directory, 'search_idx.json'), 'w', encoding='utf-8') as f:
+        json.dump(serialized_idx, f, ensure_ascii=False)
 
 def generate_author_pages(db, out_directory):
     known_authors = {}

--- a/issues/search.js
+++ b/issues/search.js
@@ -20,17 +20,11 @@ async function fetchJsonData(url) {
 
 async function initSearchIndex() {
   try {
-    const url = '/' + BASE_DIR + 'search.json';
-    fetchJsonData(url).then(p => {
+    fetchJsonData('/' + BASE_DIR + 'search.json').then(p => {
       pagesIndex = p
-      searchIndex = lunr(function() {
-        this.field("title");
-        this.field("categories");
-        this.field("content");
-        this.ref("href");
-        pagesIndex.forEach((page) => this.add(page));
-      });
-      console.log(JSON.stringify(searchIndex));
+    });
+    fetchJsonData('/' + BASE_DIR + 'search_idx.json').then(s => {
+      searchIndex = lunr.Index.load(s)
     });
   } catch (e) {
     console.log(e);

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ beautifulsoup4==4.12.3
 PyPDF2==3.0.1
 python-dateutil==2.9.0.post0
 pytz==2024.1
+lunr==0.7.0.post1
 
 
 # Use the following commands to create a virtual environment and install the required packages:


### PR DESCRIPTION
With these changes, generate.py creates the search index at build time instead of generating it on every load of a page.

Since the index is rather big, also enable provisions for static gzip compression. Numbers:

- with indent=4 (like search.json): 46.5MB
- without indent (it's all numbers anyway): 24.5MB
- without indent, gzipped: 2.8MB

(Just for reference: brotli, another compression format used at that level, gets the index to 2MB. For simplicity and maximum compatibility I stuck with the 2.8MB variant)