### PR TITLE
Add control over order of multiple articles with identical start page

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -453,7 +453,8 @@ class Article:
     def __init__(self, metadata):
         self.title = metadata['title']
 #        self.issue = metadata['issue'] # XXX should we reference the issue directly?
-        self.pages = metadata['pages']
+        self.pages_raw = metadata['pages']
+        self.pages = re.sub(r'[^\d,-]', '', metadata['pages'])
         self.id = metadata['id']
         self.issue_key = metadata['issue_key']
         self.head1 = metadata['head1']
@@ -477,6 +478,9 @@ class Article:
             return int(self.pages.split(',')[0].split('-')[0])
         except ValueError:
             raise SystemExit(f'\n---\nMetaDataError: pages tag is "{self.pages}"\n   File: "{self.path}"')
+
+    def article_sort_key(self):
+        return (self.first_page_number(), self.pages_raw)
 
     def out_filename(self):
         return self.id + '.html'
@@ -562,12 +566,12 @@ class Issue:
                 raise Exception(f"- [{issue_directory_path}] ERROR: category not in toc.txt: '{article.toc_category}' ({article.title})")
         else: # no toc_category
             category_index = len(toc_order)
-        return (article.first_page_number(), category_index, article.title)
+        return (article.article_sort_key(), category_index, article.title)
 
       sorted_articles = sorted(articles, key=lambda x: sort_by_page_number_and_toc_category(x))
 
       for index, article in enumerate(sorted_articles):
-          #print((index, article.first_page_number(), article.toc_category, article.title))
+          #print((index, article.article_sort_key(), article.toc_category, article.title))
           article.sort_index = index
       articles = sorted_articles
 
@@ -834,11 +838,11 @@ class ArticleDatabase:
             index_categories = tuple(index_categories)
             filtered_articles = [ article for article in self.articles if article.index_category and article.index_category.startswith(index_categories) and (issue_key is None or article.issue_key == issue_key)]
 
-        return sorted(filtered_articles, key=lambda x: x.first_page_number())
+        return sorted(filtered_articles, key=lambda x: x.article_sort_key())
 
     def articles_by_toc_categories(self, toc_categories, issue_key=None):
         filtered_articles = [article for article in self.articles if article.toc_category in toc_categories and (issue_key is None or article.issue_key == issue_key)]
-        return sorted(filtered_articles, key=lambda x: x.first_page_number())
+        return sorted(filtered_articles, key=lambda x: x.article_sort_key())
 
     def toc_with_articles(self, issue_key):
         issue = self.issues[issue_key]
@@ -847,7 +851,7 @@ class ArticleDatabase:
         toc_order = [""] + issue.toc_order # prepend empty category
         for toc in toc_order:
             articles = self.articles_by_toc_categories([toc], issue_key)
-            articles_sorted = sorted(articles, key=lambda x: x.first_page_number())
+            articles_sorted = sorted(articles, key=lambda x: x.article_sort_key())
             toc_entries.append({
                 'category': toc,
                 'articles': articles_sorted
@@ -871,7 +875,7 @@ class ArticleDatabase:
 
         # Sort articles in each category by issue and then by first page number
         for category, articles_list in articles_by_category.items():
-            articles_by_category[category] = sorted(articles_list, key=lambda x: (x.issue_key, x.first_page_number()))
+            articles_by_category[category] = sorted(articles_list, key=lambda x: (x.issue_key, x.article_sort_key()))
 
         sorted_categories = sorted(articles_by_category.items(), key=lambda x: x[0])
         return OrderedDict(sorted_categories)

--- a/issues/8507/48 Master Of The Lamps.html
+++ b/issues/8507/48 Master Of The Lamps.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../style.css">
     <meta name="author" content="Boris Schneider, rg">
     <meta name="64er.issue" content="7/85">
-    <meta name="64er.pages" content="48">
+    <meta name="64er.pages" content="48c">
     <meta name="64er.head1" content="Spiele-Test">
     <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">

--- a/issues/8507/48 Neue Spieletests — so wird bewertet.html
+++ b/issues/8507/48 Neue Spieletests — so wird bewertet.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../style.css">
     <meta name="author" content="Manfred Kohlen, Boris Schneider, rg">
     <meta name="64er.issue" content="7/85">
-    <meta name="64er.pages" content="48">
+    <meta name="64er.pages" content="48a">
     <meta name="64er.head1" content="Spiele-Test">
     <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_title" content="So wird bewertet">

--- a/issues/8507/48 Trends und Flops.html
+++ b/issues/8507/48 Trends und Flops.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../style.css">
     <meta name="author" content="Manfred Kohlen, Boris Schneider, rg">
     <meta name="64er.issue" content="7/85">
-    <meta name="64er.pages" content="48">
+    <meta name="64er.pages" content="48b">
     <meta name="64er.head1" content="Spiele-Test">
     <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">

--- a/issues/8507/49 Rally Speedway.html
+++ b/issues/8507/49 Rally Speedway.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../style.css">
     <meta name="author" content="Boris Schneider, rg">
     <meta name="64er.issue" content="7/85">
-    <meta name="64er.pages" content="49">
+    <meta name="64er.pages" content="49b">
     <meta name="64er.head1" content="Spiele-Test">
     <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">

--- a/issues/8507/49 Super Huey.html
+++ b/issues/8507/49 Super Huey.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../style.css">
     <meta name="author" content="Manfred Kohlen, rg">
     <meta name="64er.issue" content="7/85">
-    <meta name="64er.pages" content="49">
+    <meta name="64er.pages" content="49c">
     <meta name="64er.head1" content="Spiele-Test">
     <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">

--- a/issues/8507/49 World Series Baseball.html
+++ b/issues/8507/49 World Series Baseball.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../style.css">
     <meta name="author" content="Boris Schneider, rg">
     <meta name="64er.issue" content="7/85">
-    <meta name="64er.pages" content="49">
+    <meta name="64er.pages" content="49a">
     <meta name="64er.head1" content="Spiele-Test">
     <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">

--- a/issues/8507/50 Crystal Castles.html
+++ b/issues/8507/50 Crystal Castles.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../style.css">
     <meta name="author" content="Manfred Kohlen, rg">
     <meta name="64er.issue" content="7/85">
-    <meta name="64er.pages" content="50">
+    <meta name="64er.pages" content="50b">
     <meta name="64er.head1" content="Spiele-Test">
     <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">

--- a/issues/8507/50 Hexenküche.html
+++ b/issues/8507/50 Hexenküche.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../style.css">
     <meta name="author" content="rg">
     <meta name="64er.issue" content="7/85">
-    <meta name="64er.pages" content="50">
+    <meta name="64er.pages" content="50c">
     <meta name="64er.head1" content="Spiele-Test">
     <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">

--- a/issues/8507/50 Slapshot.html
+++ b/issues/8507/50 Slapshot.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="../style.css">
     <meta name="author" content="Manfred Kohlen, rg">
     <meta name="64er.issue" content="7/85">
-    <meta name="64er.pages" content="50">
+    <meta name="64er.pages" content="50a">
     <meta name="64er.head1" content="Spiele-Test">
     <meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Spiele-Test">


### PR DESCRIPTION
This is a proposal to add an optional `64er.page_order` header tag for giving articles with the same start page a defined order.

I'm not super happy with the approach. I would have prefered something lighter, but could come up with anything. 

Adding some markup to the `64er.pages` tag would require special handling at multiple places in the script.

Another option would be to use the filename as a secondary sort key and name the affected article htmls something like "12a ...html", "12b ...html", ... 

Anyway, I'm open for discussion and suggestions :)