### PR TITLE
Add Checksummer annotation to match magazines

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -689,6 +689,8 @@ class Issue:
                   listing_64er = checksummer.parse(listing_bin, int(data_checksummer), basicver)
                   listing_html = ""
                   for (lineno, content, checksum) in listing_64er:
+                      if data_range and not any(start <= lineno <= end for start, end in ranges):
+                          continue
                       content = content.replace("&", "&amp;")
                       content = content.replace("<", "&lt;")
                       content = content.replace("\u0346", "<span class='cbm'>")

--- a/issues/8412/30 Nichts ist ewig.html
+++ b/issues/8412/30 Nichts ist ewig.html
@@ -206,7 +206,7 @@
         <p class="source">Beim Abtippen des Programms sind die Werte in Klammern am Ende einer Zeile nicht miteinzugeben. Sie sind erst für eine spätere Ausgabe von Bedeutung. Unterstrichene Buchstaben sind mit der Shift-Taste, überstrichene mit der Commodore-Taste einzugeben. Bei Ausdrücken in eckigen Klammern ist die jeweilige Taste zu drücken.</p>
 
         <figure>
-            <pre data-filename="rom change" data-name="ROM-Change"></pre>
+            <pre data-filename="rom change" data-name="ROM-Change" data-checksummer="1"></pre>
             <figcaption>Listing »ROM-Change«</figcaption>
         </figure>
 

--- a/issues/8501/148 In die Geheimnissee der Floppy eingetaucht (Teil 4).html
+++ b/issues/8501/148 In die Geheimnissee der Floppy eingetaucht (Teil 4).html
@@ -110,7 +110,7 @@
         </aside>
 
         <figure>
-            <pre data-filename="floppyk.listing1" data-name="Directory sortieren"></pre>
+            <pre data-filename="floppyk.listing1" data-name="Directory sortieren" data-checksummer="1"></pre>
             <figcaption>Listing 1. Dieses Listing fehlte in Ausgabe 11/84</figcaption>
         </figure>
 
@@ -722,7 +722,7 @@
         <p>Es handelt sich um Listing 2. Dieses »Miniprogramm« schreiben wir in den Puffer 0 der Floppy, das heißt ab Adresse $0300. Das Basic-Programm haben wir der Kürze halber gleich an den Assemblercode angehängt. Wenn Sie das Programm starten, wird das Bit abgefragt, das beim DC für den Zustand der Schreibschutzplakette verantwortlich ist. Sie werden vielleicht wissen, daß die Floppy die Schreibschutzkerbe bei den Disketten mit Hilfe einer Lichtschranke abfragt. Ist die Lichtschranke unterbrochen, das heißt es liegt eine Diskette mit Schreibschutzaufkleber im Laufwerk, dann steht das entsprechende Bit auf 0.</p>
 
         <figure>
-            <pre data-filename="led-test_l2" data-name="Floppy-Maschinenprogramm"></pre>
+            <pre data-filename="led-test_l2" data-name="Floppy-Maschinenprogramm" data-checksummer="1"></pre>
             <figcaption>Listing 2. Unser erstes Floppy-Maschinenprogramm</figcaption>
         </figure>
 
@@ -869,7 +869,7 @@
         <p>Als Listing 3 haben wir noch einmal unser LED-Testprogramm; nur wird diese Routine durch das Basic-Programm als &amp;-File auf Diskette geschrieben und kann danach durch den schon erwähnten Befehl direkt von Diskette in den Pufferspeicher geschrieben und dort gestartet werden.</p>
 
         <figure>
-            <pre data-filename="und-generator" data-name="&-Generator"></pre>
+            <pre data-filename="und-generator" data-name="&-Generator" data-checksummer="1"></pre>
             <figcaption>Listing 3. So macht man Listing 2 zu einem »&-File«</figcaption>
         </figure>
 
@@ -902,7 +902,7 @@
         <p>Da wir stets darum bemüht sind, Ihnen die Arbeit mit der Floppy so angenehm wie möglich zu machen, haben wir unserem Artikel noch Listing 4 beigefügt. Es handelt sich hier um ein Programm, das es Ihnen gestattet, auf einfachste Weise &amp;-Files zu erstellen. Diese können sogar länger als 256 Byte sein, da das Programm dann automatisch eine Prüfsumme und die Anschlußadresse einfügt. Ununterbrochene &amp;-Files, die länger als 256 Zeichen sind, kann es ja nicht geben, da die Anzahl der Programmbytes im File nur in einem Byte abgespeichert wird.</p>
 
         <figure>
-            <pre data-filename="auto-&-maker" data-name="Auto-&-Maker"></pre>
+            <pre data-filename="auto-&-maker" data-name="Auto-&-Maker" data-checksummer="1"></pre>
             <figcaption>Listing 4. Komfortable »&-Files« erzeugen</figcaption>
         </figure>
 

--- a/issues/8501/156 500 Mark für formatierte Eingabe.html
+++ b/issues/8501/156 500 Mark für formatierte Eingabe.html
@@ -37,7 +37,7 @@
         <address class="author">(Rolf Hilchner/gk)</address>
 
         <figure>
-            <pre data-filename="format.eingabe" data-name="Formatierte Eingabe"></pre>
+            <pre data-filename="format.eingabe" data-name="Formatierte Eingabe" data-checksummer="1"></pre>
             <figcaption>Formatierte Eingabe</figcaption>
         </figure>
 

--- a/issues/8501/50 HI-EDDI- ein fantastisches Zeichen- und Malprogramm.html
+++ b/issues/8501/50 HI-EDDI- ein fantastisches Zeichen- und Malprogramm.html
@@ -480,26 +480,26 @@
         <address class="author">(Hans Haberl/gk)</address>
 
         <figure>
-            <pre data-filename="hi-print.bas" data-name="HI-PRINT Basic Lader"></pre>
+            <pre data-filename="hi-print.bas" data-name="HI-PRINT Basic Lader" data-checksummer="1"></pre>
             <figcaption>Listing 1. HI-PRINT ist die ausgezeichnete Drucker-Routine des HI-EDDI. Alle Hardcopies auf diesen Seiten wurden mit HI-PRINT erstellt. Auch dieses Unterprogramm speichert sich nach dem Starten als Maschinenprogramm auf Diskette. Beachten Sie den Beitrag »Checksummer« in dieser Ausgabe. Er gibt Ihnen wichtige Hinweise zum Abtippen.</figcaption>
         </figure>
 
         <div class="binary_download" data-filename="hi-print.prg" data-name="HI-PRINT"></div>
 
         <figure>
-            <pre data-filename="hi-exe.bas" data-name="HI-EXE Basic Lader"></pre>
+            <pre data-filename="hi-exe.bas" data-name="HI-EXE Basic Lader" data-checksummer="1"></pre>
             <figcaption>Listing 2. HI-EXE ist das umfangreichste Unterprogramm im HI-EDDI-System. Nach dem Starten speichert es sich selbst als Maschinenprogramm auf Diskette. Lesen Sie vor dem Abtippen den Beitrag »Checksummer« in dieser Ausgabe.</figcaption>
         </figure>
 
         <div class="binary_download" data-filename="hi-exe.prg" data-name="HI-EXE"></div>
 
         <figure>
-            <pre data-filename="hi-eddi" data-name="HI-EDDI"></pre>
+            <pre data-filename="hi-eddi" data-name="HI-EDDI" data-checksummer="1"></pre>
             <figcaption>Listing 3. HI-EDDI ist sozusagen das Steuerprogramm.  ruft die anderen benötigten Programme auf. Tippen Sie die REM-Zeilen nicht mit ab.</figcaption>
         </figure>
 
         <figure>
-            <pre data-filename="steuertafel" data-name="Beispiel Steuertafel"></pre>
+            <pre data-filename="steuertafel" data-name="Beispiel Steuertafel" data-checksummer="1"></pre>
             <figcaption>Listing 4. Ein Beispiel für den Aufbau einer Steuertafel für ein selbsterstelltes Menü. Einzelheiten finden Sie in der Beschreibung.</figcaption>
         </figure>
 

--- a/issues/8501/52 Der C64 als Handballtrainer.html
+++ b/issues/8501/52 Der C64 als Handballtrainer.html
@@ -197,7 +197,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="handballdemo" data-name="Handballtrainer"></pre>
+            <pre data-filename="handballdemo" data-name="Handballtrainer" data-checksummer="1"></pre>
             <figcaption>Listing: »Handballtrainer«</figcaption>
         </figure>
 

--- a/issues/8501/69 Ohne gutes Werkzeug geht es nicht SMON, Teil 3.html
+++ b/issues/8501/69 Ohne gutes Werkzeug geht es nicht SMON, Teil 3.html
@@ -219,7 +219,7 @@
         <address class="author">(N. Mann/D. Weineck/gk)</address>
 
         <figure>
-            <pre data-filename="smon teil3" data-name="DATA-Lader für SMON — Teil 3"></pre>
+            <pre data-filename="smon teil3" data-name="DATA-Lader für SMON — Teil 3" data-checksummer="1"></pre>
             <figcaption>Listing 2. Der dritte Teil des SMON als Basic-Lader</figcaption>
         </figure>
 

--- a/issues/8501/72 Checksummer — keine Fehler mehr beim Abtippen von Listings.html
+++ b/issues/8501/72 Checksummer — keine Fehler mehr beim Abtippen von Listings.html
@@ -252,11 +252,11 @@
         <address class="author">(F. Lonczewski / gk)</address>
 
         <figure>
-            <pre data-filename="checksummer 64" data-name="Checksummer 64"></pre>
+            <pre data-filename="checksummer 64" data-name="Checksummer 64" data-checksummer="1"></pre>
             <figcaption>Der Checksummer für den Commodore 64</figcaption>
         </figure>
         <figure>
-            <pre data-filename="checksummer vc20" data-name="Checksummer VC 20"></pre>
+            <pre data-filename="checksummer vc20" data-name="Checksummer VC 20" data-checksummer="1"></pre>
             <figcaption>Der Checksummer für den VC 20</figcaption>
         </figure>
 

--- a/issues/8501/76 Vier Pseudo-VICs mit 32 Sprites.html
+++ b/issues/8501/76 Vier Pseudo-VICs mit 32 Sprites.html
@@ -318,14 +318,14 @@
         </figure>
 
         <figure>
-            <pre data-filename="provic 64.bas" data-name="Provic 64 (Basic Lader)"></pre>
+            <pre data-filename="provic 64.bas" data-name="Provic 64 (Basic Lader)" data-checksummer="1"></pre>
             <figcaption>Basic-Lader »Provic 64«</figcaption>
         </figure>
 
         <div class="binary_download" data-filename="provic 64.prg" data-name="Provic 64"></div>
 
         <figure>
-            <pre data-filename="demo" data-name="Provic 64 Demo"></pre>
+            <pre data-filename="demo" data-name="Provic 64 Demo" data-checksummer="1"></pre>
             <figcaption>Demo-Listing »Provic 64«</figcaption>
         </figure>
 

--- a/issues/8501/82 Hypra-Load mal vier.html
+++ b/issues/8501/82 Hypra-Load mal vier.html
@@ -164,17 +164,17 @@
         <address class="author">(Günther Reimuth/Uwe Schönewolf/Boris Schneider/Erich Schöberl/Arnd Wängler/gk)</address>
 
         <figure>
-            <pre data-filename="hypra.boot" data-name="Hypra-Boot" data-range="267-277"></pre>
+            <pre data-filename="hypra.boot" data-name="Hypra-Boot" data-range="267-277" data-checksummer="1"></pre>
             <figcaption>Listing 1. Hypra-Boot lädt und startet ein ausgewähltes Programm automatisch.</figcaption>
         </figure>
 
         <figure>
-            <pre data-filename="hypra.load-track" data-name="Hypra-Load 0 Blöcke"></pre>
+            <pre data-filename="hypra.load-track" data-name="Hypra-Load 0 Blöcke" data-checksummer="1"></pre>
             <figcaption>Listing 2. Hypra-Load belegt keinen sichtbaren Speicherplatz mehr auf Diskette.</figcaption>
         </figure>
 
         <figure>
-            <pre data-filename="hypra-kernal" data-name="Hypra Kernal"></pre>
+            <pre data-filename="hypra-kernal" data-name="Hypra Kernal" data-checksummer="1"></pre>
             <figcaption>Listing 3. Hypra-Load fest in ein neues Betriebssystem eingebunden.</figcaption>
         </figure>
 

--- a/issues/8501/88 Parameterübergabe an Programme in Maschinensprache.html
+++ b/issues/8501/88 Parameterübergabe an Programme in Maschinensprache.html
@@ -79,11 +79,11 @@
         <address class="author">(Markus Kuhn/rg)</address>
 
         <figure>
-            <pre data-filename="parameter 1" data-name="Beispiel-Listing 1"></pre>
+            <pre data-filename="parameter 1" data-name="Beispiel-Listing 1" data-checksummer="1"></pre>
             <figcaption>Beispiel-Listing 1</figcaption>
         </figure>
         <figure>
-            <pre data-filename="parameter 2" data-name="Beispiel-Listing 2"></pre>
+            <pre data-filename="parameter 2" data-name="Beispiel-Listing 2" data-checksummer="1"></pre>
             <figcaption>Beispiel-Listing 2</figcaption>
         </figure>
 

--- a/issues/8501/90 Restore für Unterprogramme.html
+++ b/issues/8501/90 Restore für Unterprogramme.html
@@ -51,7 +51,7 @@
         <address class="author">(Stephan Pätzold/gk)</address>
 
         <figure>
-            <pre data-filename="restore up" data-name="Subroutine Restore"></pre>
+            <pre data-filename="restore up" data-name="Subroutine Restore" data-checksummer="1"></pre>
         </figure>
 
     </article>

--- a/issues/8502/123 Hires-3 – eine Super-Grafikerweiterung zum Grafikkurs.html
+++ b/issues/8502/123 Hires-3 – eine Super-Grafikerweiterung zum Grafikkurs.html
@@ -244,7 +244,7 @@
             <figcaption>Listing 1: Das Grafik-Programm Hires-3 muß mit dem MSE (siehe Seite 68) eingegeben werden</figcaption>
         </figure>
         <figure>
-            <pre data-filename="hires-3_1-test" data-name="Hires-3 Test"></pre>
+            <pre data-filename="hires-3_1-test" data-name="Hires-3 Test" data-checksummer="1"></pre>
             <figcaption>Listing 2. Dieses Programm testet Hires-3 und demonstriert einige Grafik-Befehle (zum Eintippen bitte den Beitrag »Checksummer 64« beachten)</figcaption>
         </figure>
 

--- a/issues/8502/134 Assembler ist keine Alchimie – Teil 6.html
+++ b/issues/8502/134 Assembler ist keine Alchimie – Teil 6.html
@@ -1072,7 +1072,7 @@
         <p>Damit sind wir für diesmal am Ende. Sie finden noch als Listing 1 ein kleines Testprogramm für unsere Verschieberoutine, und in Tabelle 4 wie immer, eine Zusammenfassung aller wichtigen Daten der neuen Befehle. In der nächsten Folge greifen wir nocheinmal das Thema Fließkomma auf, werden die einfachsten und kürzesten Kurzspeicher-Befehle kennenlernen und beginnen mit den leistungsfähigsten Befehlen des 6502, den indirekt-indizierten-Befehlen.</p>
 
         <figure>
-            <pre data-filename="versch.test.usr" data-name="Test und Demonstration der Verschieberoutine"></pre>
+            <pre data-filename="versch.test.usr" data-name="Test und Demonstration der Verschieberoutine" data-checksummer="1"></pre>
             <figcaption>Listing 1. Test und Demonstration der Verschieberoutine. Das Programm zeigt das Ein- und Ausschalten einer Kopfzeile auf dem Bildschirm</figcaption>
         </figure>
 

--- a/issues/8502/141 Der gläserne VC 20 – Teil 5.html
+++ b/issues/8502/141 Der gläserne VC 20 – Teil 5.html
@@ -71,7 +71,7 @@
         <p>Das Programm in Listing 1 enthält zwei Zähler. Der eine zählt die ROM-, der andere die RAM-Speicherplätze, wobei letzterer genau doppelt so schnell läuft, denn eine ROM-Zeile soll ja zweimal hintereinander ins RAM geschrieben werden (dieses »Strecken« eines Zeichens ist in Bild 2 zu sehen). Da diese Schriftart natürlich besonders auffällig ist, eignet sie sich beispielsweise für Schaufensterwerbung oder ähnliches.</p>
 
         <figure>
-            <pre data-filename="16-bit-zeichen" data-name="Doppelt hohe Zeichen"></pre>
+            <pre data-filename="16-bit-zeichen" data-name="Doppelt hohe Zeichen" data-checksummer="1"></pre>
             <figcaption>Listing 1. Doppelt hohe Zeichendarstellung</figcaption>
         </figure>
 
@@ -350,19 +350,19 @@
         <address class="author">(Christoph Sauer/ev)</address>
 
         <figure>
-            <pre data-filename="bitmapping" data-name="Bitmapping"></pre>
+            <pre data-filename="bitmapping" data-name="Bitmapping" data-checksummer="1"></pre>
             <figcaption>Listing 2. Die Bitmapping-Routine</figcaption>
         </figure>
         <figure>
-            <pre data-filename="joypaint 1" data-name="Joypaint 1"></pre>
+            <pre data-filename="joypaint 1" data-name="Joypaint 1" data-checksummer="1"></pre>
             <figcaption>Listing 3. Basic-Lader »Joypaint« (Teil 1)</figcaption>
         </figure>
         <figure>
-            <pre data-filename="joypaint 2" data-name="Joypaint 2"></pre>
+            <pre data-filename="joypaint 2" data-name="Joypaint 2" data-checksummer="1"></pre>
             <figcaption>Listing 4. Basic-Lader »Joypaint« (Teil 2, Schluß)</figcaption>
         </figure>
         <figure>
-            <pre data-filename="multicolor-demo" data-name="Multicolor-Demo"></pre>
+            <pre data-filename="multicolor-demo" data-name="Multicolor-Demo" data-checksummer="1"></pre>
             <figcaption>Listing 5. Ein Multicolor-Demo</figcaption>
         </figure>
 

--- a/issues/8502/147 Stringprogrammierung in Maschinensprache Teil 2.html
+++ b/issues/8502/147 Stringprogrammierung in Maschinensprache Teil 2.html
@@ -127,7 +127,7 @@ LBL5
         <p>Nur wenn »String1« den gleichen Namen hat wie »String2«, entsteht ein Müllstring, nämlich der alte Inhalt der Stringvariablen. Für die, die es nun gar nicht mehr erwarten können, dieses Programm auszuprobieren, gibt es in Listing 2 einen Basic-Lader. Listing 1 kann direkt mit einem Assembler oder auch mit dem SMON eingegeben werden. Anhand dieses Programms, das alle wichtigen ROM-Routinen, die mit Strings zu tun haben, aufruft, wollen wir nun die Programmierung solcher Routinen erarbeiten.</p>
 
         <figure>
-            <pre data-filename="format.stringkur" data-name="FORMAT-Routine (Basic Lader)"></pre>
+            <pre data-filename="format.stringkur" data-name="FORMAT-Routine (Basic Lader)" data-checksummer="1"></pre>
             <figcaption>Listing 2. Basic-Lader der FORMAT-Routine</figcaption>
         </figure>
 

--- a/issues/8502/152 Dem Klang auf der Spur - Teil 3.html
+++ b/issues/8502/152 Dem Klang auf der Spur - Teil 3.html
@@ -308,27 +308,27 @@
         <address class="author">(Thomas Krätzig/aa)</address>
 
         <figure>
-            <pre data-filename="musik 1" data-name="Listing 1"></pre>
-            <figcaption>Listing 1. Mit Programm 1 kann man sich damit vertraut machen, wie einzelne Töne mit verschiedenen Kurvenformen und Hüllkurven klingen. Die Parameter lassen sich in den DÄTA-Zeilen am Ende des Programms leicht modifizieren.</figcaption>
+            <pre data-filename="musik 1" data-name="Listing 1" data-checksummer="1"></pre>
+            <figcaption>Listing 1. Mit Programm 1 kann man sich damit vertraut machen, wie einzelne Töne mit verschiedenen Kurvenformen und Hüllkurven klingen. Die Parameter lassen sich in den DATA-Zeilen am Ende des Programms leicht modifizieren.</figcaption>
         </figure>
         <figure>
-            <pre data-filename="musik 2" data-name="Listing 2"></pre>
+            <pre data-filename="musik 2" data-name="Listing 2" data-checksummer="1"></pre>
             <figcaption>Listing 2. Dieser Einzeiler ist gegenüber dem übersichtlichen, aber etwas aufgeblasenen Programm 1 so ziemlich die kompakteste Lösung, um dem SID einen Ton zu entlocken. Zur Eingabe muß man die Basic-Schlüsselwörter abkürzen.</figcaption>
         </figure>
         <figure>
-            <pre data-filename="musik 3" data-name="Listing 3"></pre>
+            <pre data-filename="musik 3" data-name="Listing 3" data-checksummer="1"></pre>
             <figcaption>Listing 3. Durch Verändern des höherwertigen Frequenz-Bytes in kleinen Schritten entsteht der Eindruck, daß der Ton kontinuierlich in der Höhe schwankt</figcaption>
         </figure>
         <figure>
-            <pre data-filename="musik 4" data-name="Listing 4"></pre>
+            <pre data-filename="musik 4" data-name="Listing 4" data-checksummer="1"></pre>
             <figcaption>Listing 4. Die Programmierung des SID über POKE-Befehle ist mühsam. Drei kleine Maschinenprogramme, die man auch als Erweiterung des BASIC-Interpreters auffassen kann, werden von Programm 5 und 6 aufgerufen.</figcaption>
         </figure>
         <figure>
-            <pre data-filename="musik 5" data-name="Listing 5"></pre>
+            <pre data-filename="musik 5" data-name="Listing 5" data-checksummer="1"></pre>
             <figcaption>Listing 5. Programm 5 zeigt, wie vielfältig Rauschen klingen kann. Die Parametersätze in den DATA-Zeilen kann man beliebig verändern oder erweitern.</figcaption>
         </figure>
         <figure>
-            <pre data-filename="musik 6" data-name="Listing 6"></pre>
+            <pre data-filename="musik 6" data-name="Listing 6" data-checksummer="1"></pre>
             <figcaption>Listing 6. Die Frequenzen der temperierten Stimmung werden über 2 Oktaven errechnet. Anschließend wird daraus eine Zufallstonfolge erzeugt. Durch zyklisches Ansteuern aller drei Stimmen haben die Töne Zeit zum Ausklingen.</figcaption>
         </figure>
 

--- a/issues/8502/156 500 Mark für das lustigste Programm.html
+++ b/issues/8502/156 500 Mark für das lustigste Programm.html
@@ -39,7 +39,7 @@
         <address class="author">(gk)</address>
 
         <figure>
-            <pre data-filename="notlandung" data-name="Notlandung"></pre>
+            <pre data-filename="notlandung" data-name="Notlandung" data-checksummer="1"></pre>
             <figcaption>»Notlandung«, das lustige Programm</figcaption>
         </figure>
 

--- a/issues/8502/34 Basic-Programm auf Trab gebracht – Compiler im Test.html
+++ b/issues/8502/34 Basic-Programm auf Trab gebracht – Compiler im Test.html
@@ -381,7 +381,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="benchmark-test" data-name="Benchmark für Compiler"></pre>
+            <pre data-filename="benchmark-test" data-name="Benchmark für Compiler" data-checksummer="1"></pre>
             <figcaption>Listing 1. Die in Tabelle 2 zusammengefaßten Ergebnisse wurden mit diesem Programm ermittelt. Die Zeit für zum Beispiel 1000 GOSUB-RETURN erhält man, indem die Zeit für Benchmark 4 von der Zeit für Benchmark 5 abgezogen wird.</figcaption>
         </figure>
 

--- a/issues/8502/51 Das Grab des Pharao.html
+++ b/issues/8502/51 Das Grab des Pharao.html
@@ -168,7 +168,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="grab des pharao" data-name="Grab des Pharao"></pre>
+            <pre data-filename="grab des pharao" data-name="Grab des Pharao" data-checksummer="1"></pre>
             <figcaption>Listing »Grab des Pharao«. Beachten Sie beim Eintippen bitte den Beitrag über den »Checksummer 64«</figcaption>
         </figure>
 

--- a/issues/8502/52 Familienplanung.html
+++ b/issues/8502/52 Familienplanung.html
@@ -335,7 +335,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="familienplanung" data-name="Familienplanung"></pre>
+            <pre data-filename="familienplanung" data-name="Familienplanung" data-checksummer="1"></pre>
             <figcaption>Listing »Familienplanung«</figcaption>
         </figure>
 

--- a/issues/8502/65 Checksummer — keine Fehler mehr beim Abtippen von Listings.html
+++ b/issues/8502/65 Checksummer — keine Fehler mehr beim Abtippen von Listings.html
@@ -250,11 +250,11 @@
         <address class="author">(F. Lonczewski / gk)</address>
 
         <figure>
-            <pre data-filename="checksummer 64" data-name="Checksummer 64"></pre>
+            <pre data-filename="checksummer 64" data-name="Checksummer 64" data-checksummer="1"></pre>
             <figcaption>Der Checksummer für den Commodore 64</figcaption>
         </figure>
         <figure>
-            <pre data-filename="checksummer vc20" data-name="Checksummer VC 20"></pre>
+            <pre data-filename="checksummer vc20" data-name="Checksummer VC 20" data-checksummer="1"></pre>
             <figcaption>Der Checksummer für den VC 20</figcaption>
         </figure>
 

--- a/issues/8502/68 MSE – Abtippen  sicher und leicht gemacht.html
+++ b/issues/8502/68 MSE – Abtippen  sicher und leicht gemacht.html
@@ -85,7 +85,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="mse lader" data-name="MSE-Lader"></pre>
+            <pre data-filename="mse lader" data-name="MSE-Lader" data-checksummer="1"></pre>
             <figcaption>Listing MSE. Dieses Programm erleichtert Ihnen die  von Maschinenprogrammen ganz erheblich. Sie sparen Zeit und machen keine Fehler mehr.</figcaption>
         </figure>
         <div class="binary_download" data-filename="mse v1.0.prg" data-name="MSE V1.0"></div>

--- a/issues/8502/70 VC 20 steuert Super 8-Kamera.html
+++ b/issues/8502/70 VC 20 steuert Super 8-Kamera.html
@@ -79,7 +79,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="super 8" data-name="Super 8-Steuerung"></pre>
+            <pre data-filename="super 8" data-name="Super 8-Steuerung" data-checksummer="1"></pre>
             <figcaption>Listing »Super 8-Steuerung«</figcaption>
         </figure>
     </article>

--- a/issues/8502/78 Q + Bert.html
+++ b/issues/8502/78 Q + Bert.html
@@ -293,7 +293,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="q+bert 20" data-name="Q+Bert"></pre>
+            <pre data-filename="q+bert 20" data-name="Q+Bert" data-checksummer="1"></pre>
             <figcaption>Listing »Q+Bert«</figcaption>
         </figure>
 

--- a/issues/8502/81 Gehirntraining mit Supermemory.html
+++ b/issues/8502/81 Gehirntraining mit Supermemory.html
@@ -101,7 +101,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="super memory" data-name="Super Memory"></pre>
+            <pre data-filename="super memory" data-name="Super Memory" data-checksummer="1"></pre>
             <figcaption>Listing »Super Memory«</figcaption>
         </figure>
     </article>

--- a/issues/8502/88 Als die Bilder laufen lernten.html
+++ b/issues/8502/88 Als die Bilder laufen lernten.html
@@ -76,7 +76,7 @@
             <figcaption>Listing 1. »Als die Bilder laufen lernten...«. Das Programm muß mit dem MSE auf Seite 68 eingegeben werden</figcaption>
         </figure>
         <figure>
-            <pre data-filename="rolling-demo" data-name="Rolling Demo"></pre>
+            <pre data-filename="rolling-demo" data-name="Rolling Demo" data-checksummer="1"></pre>
             <figcaption>Listing 2. Dieses Demo-Programm zeigt Ihnen die verblüffende Wirkung des Scrollens in allen Richtungen</figcaption>
         </figure>
 

--- a/issues/8502/92 RAM-Floppy.html
+++ b/issues/8502/92 RAM-Floppy.html
@@ -37,7 +37,7 @@
         <address class="author">(Uwe Klatt/hm)</address>
 
         <figure>
-            <pre data-filename="ram-floppy" data-name="Ram-Floppy"></pre>
+            <pre data-filename="ram-floppy" data-name="Ram-Floppy" data-checksummer="1"></pre>
             <figcaption>Listing zu »Ram-Floppy«</figcaption>
         </figure>
 

--- a/issues/8503/130 In die Geheimnisse der Floppy eingetaucht (Teil 5).html
+++ b/issues/8503/130 In die Geheimnisse der Floppy eingetaucht (Teil 5).html
@@ -402,7 +402,7 @@ AUF LESEN UMSCHALTEN:
         <address class="author">(Karsten Schramm/gk)</address>
 
         <figure>
-            <pre data-filename="read error 22" data-name="READ ERROR 22 erzeugen"></pre>
+            <pre data-filename="read error 22" data-name="READ ERROR 22 erzeugen" data-checksummer="2"></pre>
             <figcaption>Listing 2a. Ein READ ERROR 22 wird erzeugt (in einem beliebigen Sektor)</figcaption>
         </figure>
         <figure>
@@ -448,7 +448,7 @@ AUF LESEN UMSCHALTEN:
             <figcaption>Listing 2b. <a href="#fehlerteufelchen" class="fehlerteufelchen_link">Herstellen eines »22, READ ERROR« (Assemblerprogramm)</a></figcaption>
         </figure>
         <figure>
-            <pre data-filename="read error 23" data-name="READ ERROR 23 erzeugen"></pre>
+            <pre data-filename="read error 23" data-name="READ ERROR 23 erzeugen" data-checksummer="2"></pre>
             <figcaption>Listing 3a. Ein READ ERROR 23 wird erzeugt</figcaption>
         </figure>
         <figure>

--- a/issues/8503/136 Hires-3 – 15 neue Basic-Befehle (Teil 2).html
+++ b/issues/8503/136 Hires-3 – 15 neue Basic-Befehle (Teil 2).html
@@ -1027,7 +1027,7 @@
             <figcaption>Listing 1. Hires 3, 2. Teil. Dieses Programm muß mit dem MSE (als Listing in dieser Ausgabe) eingegeben werden</figcaption>
         </figure>
         <figure>
-            <pre data-filename="hires-3_2-test" data-name="Hires-3 Test"></pre>
+            <pre data-filename="hires-3_2-test" data-name="Hires-3 Test" data-checksummer="2"></pre>
             <figcaption>Listing 2. Mit diesem Programm testen Sie Hires-3</figcaption>
         </figure>
         <div class="binary_download" data-filename="hires-3.prg" data-name="Hires-3"></div>

--- a/issues/8503/155 Der gläserne VC 20 — Teil 6.html
+++ b/issues/8503/155 Der gläserne VC 20 — Teil 6.html
@@ -301,7 +301,7 @@
         </aside>
 
         <figure>
-            <pre data-filename="irq-clock vc 20" data-name="IRQ-Clock"></pre>
+            <pre data-filename="irq-clock vc 20" data-name="IRQ-Clock" data-checksummer="2"></pre>
             <figcaption>Listing 1. »IRQ-Clock« (Basic-Lader)</figcaption>
         </figure>
         <figure>
@@ -446,7 +446,7 @@
             <figcaption>Listing 2. »IRQ Clock« (Assembler-Listing)</figcaption>
         </figure>
         <figure>
-            <pre data-filename="autostart 20_64" data-name="Autostart"></pre>
+            <pre data-filename="autostart 20_64" data-name="Autostart" data-checksummer="2"></pre>
             <figcaption>Listing 3. »Autostart« für C 64 / VC 20</figcaption>
         </figure>
         <figure>

--- a/issues/8503/41 22 Read Error - Theorie und Praxis.html
+++ b/issues/8503/41 22 Read Error - Theorie und Praxis.html
@@ -178,7 +178,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="son of destroyer" data-name="Son of Destroyer"></pre>
+            <pre data-filename="son of destroyer" data-name="Son of Destroyer" data-checksummer="2"></pre>
             <figcaption>Listing »Son of Destroyer«</figcaption>
         </figure>
     </article>

--- a/issues/8503/50 Ohne Organisation kein Tor.html
+++ b/issues/8503/50 Ohne Organisation kein Tor.html
@@ -683,7 +683,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="ligatab b1" data-name="Ligatab"></pre>
+            <pre data-filename="ligatab b1" data-name="Ligatab" data-checksummer="2"></pre>
             <figcaption>Listing »Ligatab«</figcaption>
         </figure>
         <div class="binary_download" data-filename="c_ligatab b1_a.prg" data-name="Ligatab (Compiliert)"></div>

--- a/issues/8503/52 »Gut Ziel« mit dem C64.html
+++ b/issues/8503/52 »Gut Ziel« mit dem C64.html
@@ -64,7 +64,7 @@
         <address class="author">(Ernst Merk/hm)</address>
 
         <figure>
-            <pre data-filename="meisterschuetze" data-name="Gut Ziel"></pre>
+            <pre data-filename="meisterschuetze" data-name="Gut Ziel" data-checksummer="2"></pre>
             <figcaption>Listing zu »Gut Ziel« mit dem C 64</figcaption>
         </figure>
     </article>

--- a/issues/8503/68 Neuer Checksummer 64 — blitzschnell und kürzer.html
+++ b/issues/8503/68 Neuer Checksummer 64 — blitzschnell und kürzer.html
@@ -302,11 +302,11 @@
         </figure>
 
         <figure>
-            <pre data-filename="checksummer vc20" data-name="Checksummer (VC 20)"></pre>
+            <pre data-filename="checksummer vc20" data-name="Checksummer (VC 20)" data-checksummer="2"></pre>
             <figcaption>Der Checksummer für den VC 20</figcaption>
         </figure>
         <figure>
-            <pre data-filename="checksum.schnell" data-name="Neuer Checksummer (C 64)"></pre>
+            <pre data-filename="checksum.schnell" data-name="Neuer Checksummer (C 64)" data-checksummer="2"></pre>
             <figcaption>Der neue Checksummer für den Commodore 64</figcaption>
         </figure>
     </article>

--- a/issues/8503/71 Elektrotechnisches Zeichnen mit dem VC 20.html
+++ b/issues/8503/71 Elektrotechnisches Zeichnen mit dem VC 20.html
@@ -206,11 +206,11 @@
         </figure>
 
         <figure>
-            <pre data-filename="e. zeichnen 1" data-name="Elektrotechnisches Zeichnen (Maschinenroutinen)"></pre>
+            <pre data-filename="e. zeichnen 1" data-name="Elektrotechnisches Zeichnen (Maschinenroutinen)" data-checksummer="2"></pre>
             <figcaption>Listing 1. Maschinenroutinen zu »Elektrotechnisches Zeichnen« als Basic-Lader. Bitte beachten Sie beim Eintippen den Checksummer VC 20 auf Seite 69</figcaption>
         </figure>
         <figure>
-            <pre data-filename="e. zeichnen 2" data-name="Elektrotechnisches Zeichnen (Hauptprogramm)"></pre>
+            <pre data-filename="e. zeichnen 2" data-name="Elektrotechnisches Zeichnen (Hauptprogramm)" data-checksummer="2"></pre>
             <figcaption>Listing 2. »Elektrotechnisches Zeichnen« (Hauptprogramm)</figcaption>
         </figure>
     </article>

--- a/issues/8503/78 MSE — Abtippen sicher und leicht gemacht.html
+++ b/issues/8503/78 MSE — Abtippen sicher und leicht gemacht.html
@@ -82,7 +82,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="mse lader" data-name="MSE-Lader"></pre>
+            <pre data-filename="mse lader" data-name="MSE-Lader" data-checksummer="2"></pre>
             <figcaption>Listing MSE. Dieses Programm erleichtert Ihnen die Eingabe von Maschinenprogrammen ganz erheblich. Sie sparen Zeit und machen keine Fehler mehr.</figcaption>
         </figure>
     </article>

--- a/issues/8503/88 Tips und Erweiterungen zu Hi-Eddi und Simons Basic.html
+++ b/issues/8503/88 Tips und Erweiterungen zu Hi-Eddi und Simons Basic.html
@@ -150,15 +150,15 @@
         </aside>
 
         <figure>
-            <pre data-filename="screensave" data-name="Screensave"></pre>
+            <pre data-filename="screensave" data-name="Screensave" data-checksummer="2"></pre>
             <figcaption>Listing 1. Screensave: Erweiterung für Simons Basic, um dessen Hi-Res-Bilder zu speichern und zu laden.</figcaption>
         </figure>
         <figure>
-            <pre data-filename="saver" data-name="Saver"></pre>
+            <pre data-filename="saver" data-name="Saver" data-checksummer="2"></pre>
             <figcaption>Listing 2. Saver: Mit dieser Routine können Sie ein um zum Beispiel Listing 1 erweitertes Simons Basic speichern</figcaption>
         </figure>
         <figure>
-            <pre data-filename="pic-loader" data-name="Pic-Lader"></pre>
+            <pre data-filename="pic-loader" data-name="Pic-Lader" data-checksummer="2"></pre>
             <figcaption>Listing 3. Pic-Lader: Dieses Programm erlaubt es, »Hi- Eddi«-Bilder in eigene Basic-Programme oder mit der Simons-Basic-Modul-Version zu laden</figcaption>
         </figure>
     </article>

--- a/issues/8504/131 Dem Klang auf der Spur, Teil 4.html
+++ b/issues/8504/131 Dem Klang auf der Spur, Teil 4.html
@@ -197,7 +197,7 @@
             <figcaption>Listing 1. Das Programm »Modulator« ist der Grundstock für ein, in den nächsten Folgen entwickelndes, Synthesizer- und Sequenzerprogramms. Dieses Listing bitte mit dem MSE eingeben.</figcaption>
         </figure>
         <figure>
-            <pre data-filename="modulator.test" data-name="Modulator Testprogramm"></pre>
+            <pre data-filename="modulator.test" data-name="Modulator Testprogramm" data-checksummer="2"></pre>
             <figcaption>Listing 2. Testprogramm für »Modulator«. Dieses Listing bitte mit dem Checksummer eingeben.</figcaption>
         </figure>
     </article>

--- a/issues/8504/138 Assembler ist keine Alchimie — Teil 8.html
+++ b/issues/8504/138 Assembler ist keine Alchimie — Teil 8.html
@@ -234,7 +234,7 @@
         <p>Der Pfeil weist auf das Vorzeichenbit. Man spricht hier auch vom »gepackten« Format. Damit das alles nun nicht nur graue Theorie bleibt und Sie auch aus eigenem Erleben diese Zahlenformate sehen können, wollen wir hier ein kleines Testprogramm ausprobieren. Es wird Ihnen auch später noch gute Dienste leisten können, wenn Sie mal irgendwelche Zahlen in das FLPT- (also FAC oder ARG) oder ins MFLPT-Format umrechnen müssen. Zu Fuß ist das ja — wie Sie nun wissen — ganz schön haarig! Wie so oft, besteht auch dieses Programm aus einem Basic-Teil, der die Benutzerführung übernimmt und zwei kleinen Maschinenroutinen, die per USR-Vektor angesprungen werden. In diesen Assembler-Programmteilen sind zwei Interpreter-Routinen verborgen, die nützlich und daher erklärenswert sind. Als Listing 1 ist das Basic-Aufrufprogramm abgedruckt.</p>
 
         <figure>
-            <pre data-filename="ass.kurs teil8" data-name="Assembler-Testprogramm"></pre>
+            <pre data-filename="ass.kurs teil8" data-name="Assembler-Testprogramm" data-checksummer="2"></pre>
             <figcaption>Listing 1. Testprogramm für die beiden kleinen Assembler-
                 Routinen. Die Bedienung ist im Artikel erklärt.</figcaption>
         </figure>

--- a/issues/8504/148 Effektives Programmieren (4)_ Daten sortieren mit dem Computer — Methoden, Techniken, Programme.html
+++ b/issues/8504/148 Effektives Programmieren (4)_ Daten sortieren mit dem Computer — Methoden, Techniken, Programme.html
@@ -119,7 +119,7 @@
         <p>In Listing 1 sehen Sie ein Programm abgedruckt, das für alle weiteren Sortierprogramme als Rahmen dienen soll. Es hat die Aufgabe, ein Feld zu erstellen und die Ausgabe auf Drucker oder Bildschirm festzulegen. Das Feld kann wahlweise zufällig oder von Hand bestimmt werden und besteht aus Stringvariablen der Länge 3.</p>
 
         <figure>
-            <pre data-filename="insertion sort" data-name="Rahmenprogramm Start" data-range="10-4050"></pre>
+            <pre data-filename="insertion sort" data-name="Rahmenprogramm Start" data-range="10-4050" data-checksummer="2"></pre>
             <!-- TODO: hide from downloads (needs CMS feature) -->
             <figcaption>Listing 1. Dieses Programm erstellt das Sortierfeld und ist der Rahmen für alle Sortierroutinen, die nur zusammen mit Listing 1 und Listing 2 laufen</figcaption>
         </figure>
@@ -127,7 +127,7 @@
         <p>In Listing 2 sehen Sie den Abschluß des Sortierprogramms. Alle Algorithmen sind nur mit diesen Rahmenprogrammen lauffähig.</p>
 
         <figure>
-            <pre data-filename="insertion sort" data-name="Rahmenprogramm Ende" data-range="50000-50050"></pre>
+            <pre data-filename="insertion sort" data-name="Rahmenprogramm Ende" data-range="50000-50050" data-checksummer="2"></pre>
             <!-- TODO: hide from downloads (needs CMS feature) -->
             <figcaption>Listing 2. Der Abschluß des Sortierprogramms. Es muß zusammen mit Listing 1 und der Sortierroutine (Listing 3 oder 4) gestartet werden</figcaption>
         </figure>
@@ -135,7 +135,7 @@
         <p>Listing 3 schließlich zeigt ein Programm für das Sortieren durch direktes Einfügen. Wie Sie aus dem Listing erkennen können, ist es wichtig, daß das erste Element des Feldes nicht, oder als das absolut kleinste Element definiert wird, da es die letzte und höchste Vergleichstufe darstellt und somit nicht mehr vertauscht werden kann, da das Programm sonst über die Grenzen des Feldes hinaus arbeiten müßte. In unserem Fall ist dieses Element (A$(0)) ein Leerstring C").</p>
 
         <figure>
-            <pre data-filename="insertion sort" data-name="Straight Insertion Sort" data-range="10000-10140"></pre>
+            <pre data-filename="insertion sort" data-name="Straight Insertion Sort" data-range="10000-10140" data-checksummer="2"></pre>
             <figcaption>Listing 3. Der einfachste Sortieralgorithmus: Straight Insertion oder Sortieren durch direktes Einfügen</figcaption>
         </figure>
 
@@ -194,7 +194,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="bubble sort" data-name="Bubblesort" data-range="10000-10100"></pre>
+            <pre data-filename="bubble sort" data-name="Bubblesort" data-range="10000-10100" data-checksummer="2"></pre>
             <figcaption>Listing 4. Bubblesort ist ebenfalls eine einfache, aber auch nicht gerade die schnellste Sortiermethode</figcaption>
         </figure>
 

--- a/issues/8504/50 Epson bedruckt Ostereier.html
+++ b/issues/8504/50 Epson bedruckt Ostereier.html
@@ -36,7 +36,7 @@
         <address class="author">(Jürgen Kruse/Arnd Wängler/ev)</address>
 
         <figure>
-            <pre data-filename="ostereier" data-name="Ostereier"></pre>
+            <pre data-filename="ostereier" data-name="Ostereier" data-checksummer="2"></pre>
             <figcaption>Listing der Treibersoftware für Epson JX-80- und Commodore-Drucker</figcaption>
         </figure>
 

--- a/issues/8504/54 Neuer Checksummer 64 — blitzschnell und kürzer.html
+++ b/issues/8504/54 Neuer Checksummer 64 — blitzschnell und kürzer.html
@@ -256,11 +256,11 @@
         </figure>
 
         <figure>
-            <pre data-filename="checksum.schnell" data-name="Checksummer (C 64)"></pre>
+            <pre data-filename="checksum.schnell" data-name="Checksummer (C 64)" data-checksummer="2"></pre>
             <figcaption>Der Checksummer für den C 64</figcaption>
         </figure>
         <figure>
-            <pre data-filename="checksummer vc20" data-name="Checksummer (VC 20)"></pre>
+            <pre data-filename="checksummer vc20" data-name="Checksummer (VC 20)" data-checksummer="2"></pre>
             <figcaption>Der Checksummer für den VC 20</figcaption>
         </figure>
     </article>

--- a/issues/8504/57 MSE — Abtippen sicher und leicht gemacht.html
+++ b/issues/8504/57 MSE — Abtippen sicher und leicht gemacht.html
@@ -80,7 +80,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="mse lader" data-name="MSE Lader"></pre>
+            <pre data-filename="mse lader" data-name="MSE Lader" data-checksummer="2"></pre>
             <figcaption>Listing MSE. Dieses Programm erleichtert Ihnen die Eingabe von Maschinenprogrammen ganz erheblich. Sie sparen Zeit und machen keine Fehler mehr.</figcaption>
         </figure>
         <div class="binary_download" data-filename="mse v1.0.prg" data-name="MSE V1.0"></div>

--- a/issues/8504/68 Schachmeister erweitert.html
+++ b/issues/8504/68 Schachmeister erweitert.html
@@ -59,7 +59,7 @@
         <address class="author">(Heiko Becke/rg)</address>
 
         <figure>
-            <pre data-filename="schachmeister" data-name="Schachmeister erweitert" data-range="895,1865,1900,2041,2042,2043,2044,2045,2046,2050,2301,2302,2303,2304,2305,2306,2320,2350,2351,2352,2353,2354,2355,2356,2357,2360,2380,2381,2382,2383,2384,2390,2400,2410,2530"></pre>
+            <pre data-filename="schachmeister" data-name="Schachmeister erweitert" data-range="895,1865,1900,2041,2042,2043,2044,2045,2046,2050,2301,2302,2303,2304,2305,2306,2320,2350,2351,2352,2353,2354,2355,2356,2357,2360,2380,2381,2382,2383,2384,2390,2400,2410,2530" data-checksummer="2"></pre>
             <figcaption>Diese Zeilen müssen dem Listing »Schachmeister« beigefügt werden</figcaption>
         </figure>
     </article>

--- a/issues/8504/69 Funktionen im Netz.html
+++ b/issues/8504/69 Funktionen im Netz.html
@@ -147,11 +147,11 @@
             <figcaption>Listing 1. 3-D-Grafikroutine. Das Listing muß mit dem MSE eingegeben werden. </figcaption>
         </figure>
         <figure>
-            <pre data-filename="rot-demo" data-name="ROT Demo"></pre>
+            <pre data-filename="rot-demo" data-name="ROT Demo" data-checksummer="2"></pre>
             <figcaption>Listing 2. Demo-Programm zu SYS ROT</figcaption>
         </figure>
         <figure>
-            <pre data-filename="x.y-demo 1" data-name="XY Demo"></pre>
+            <pre data-filename="x.y-demo 1" data-name="XY Demo" data-checksummer="2"></pre>
             <figcaption>Listing 3. Demo-Programm zu SYS XY</figcaption>
         </figure>
         <!-- There is also "x.y-demo 2" on the disk.  -->

--- a/issues/8504/73 Supergrafik III.html
+++ b/issues/8504/73 Supergrafik III.html
@@ -90,7 +90,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="supergrafik iii" data-name="Supergrafik III"></pre>
+            <pre data-filename="supergrafik iii" data-name="Supergrafik III" data-checksummer="2"></pre>
             <figcaption>Listing. Das Programm zur Darstellung dreidimensionaler Funktionen auf dem VC 20</figcaption>
         </figure>
     </article>

--- a/issues/8504/75 Neues vom Hypra-Load_ Hypra-Perfekt.html
+++ b/issues/8504/75 Neues vom Hypra-Load_ Hypra-Perfekt.html
@@ -183,7 +183,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="hypra-perfekt" data-name="Hypra-Perfekt"></pre>
+            <pre data-filename="hypra-perfekt" data-name="Hypra-Perfekt" data-checksummer="2"></pre>
             <figcaption>Das Hypra-Perfekt-Listing</figcaption>
         </figure>
     </article>

--- a/issues/8504/79 Print-List.html
+++ b/issues/8504/79 Print-List.html
@@ -38,7 +38,7 @@
         <address class="author">(Peter Zuser/hm)</address>
 
         <figure>
-            <pre data-filename="print-list" data-name="Print-List"></pre>
+            <pre data-filename="print-list" data-name="Print-List" data-checksummer="2"></pre>
             <figcaption>Listing zu Print-List</figcaption>
         </figure>
     </article>

--- a/issues/8504/80 Befehlserweiterung für den C 64.html
+++ b/issues/8504/80 Befehlserweiterung für den C 64.html
@@ -126,7 +126,7 @@
         <address class="author">(Heino Velder/ev)</address>
 
         <figure>
-            <pre data-filename="befehls-erw." data-name="Basic-Erweiterungen"></pre>
+            <pre data-filename="befehls-erw." data-name="Basic-Erweiterungen" data-checksummer="2"></pre>
             <figcaption>Listing »Basic-Erweiterungen«</figcaption>
         </figure>
     </article>

--- a/issues/8504/83 VC 20-Programme schützen.html
+++ b/issues/8504/83 VC 20-Programme schützen.html
@@ -118,11 +118,11 @@
         </figure>
 
         <figure>
-            <pre data-filename="prg.schutz vc 20" data-name="Beispiel zum Programmschutz"></pre>
+            <pre data-filename="prg.schutz vc 20" data-name="Beispiel zum Programmschutz" data-checksummer="2"></pre>
             <figcaption>Listing 1. Beispiel zum Programmschutz</figcaption>
         </figure>
         <figure>
-            <pre data-filename="prg.schutz autos" data-name="Autostart in Maschinensprache"></pre>
+            <pre data-filename="prg.schutz autos" data-name="Autostart in Maschinensprache" data-checksummer="2"></pre>
             <figcaption>Listing 2. Autostart in Maschinensprache</figcaption>
         </figure>
     </article>

--- a/issues/8504/87 Window 64_ Fenstertechnik für den Commodore.html
+++ b/issues/8504/87 Window 64_ Fenstertechnik für den Commodore.html
@@ -136,7 +136,7 @@
             <figcaption>Listing 1. Das Hauptprogramm Window 64. Es muß mit dem MSE auf Seite 57 eingegeben werden.</figcaption>
         </figure>
         <figure>
-            <pre data-filename="demo window64" data-name="Window 64 Demo"></pre>
+            <pre data-filename="demo window64" data-name="Window 64 Demo" data-checksummer="2"></pre>
         </figure>
 
         <div class="binary_download" data-filename="window64.prg" data-name="Window 64 $C000"></div>

--- a/issues/8505/138 Assembler ist keine Alchimie — Teil 9.html
+++ b/issues/8505/138 Assembler ist keine Alchimie — Teil 9.html
@@ -1016,7 +1016,7 @@
         </figure>
         <div class="binary_download" data-filename="ass.-9_prog.1.prg" data-name="16-Bit-Division"></div>
         <figure>
-            <pre data-filename="ass.-9_prog.2" data-name="XXXXXXXXXXXX"></pre>
+            <pre data-filename="ass.-9_prog.2" data-name="XXXXXXXXXXXX" data-checksummer="2"></pre>
             <figcaption>Programm 2. Das Demo-Programm zur neuen Verschieberoutine. Vorher müssen Programm 3 und Programm 4 geladen werden.</figcaption>
         </figure>
         <figure>

--- a/issues/8505/145 In die Geheimnisse der Floppy eingetaucht _ Teil 6.html
+++ b/issues/8505/145 In die Geheimnisse der Floppy eingetaucht _ Teil 6.html
@@ -631,7 +631,7 @@
             <figcaption>Listing 1. Eine neue Formatierroutine. Eine Diskette wird nicht nur schneller sondern Sie können auch angeben, welche formatiert werden sollen. Was das für Vorteile hat, erfahren Sie im Bericht. Zwischen den Adressen C348 und C3DA liegt eine ASCII-Tabelle</figcaption>
         </figure>
         <figure>
-            <pre data-filename="format-system lader" data-name="Format-System (Basic Lader)"></pre>
+            <pre data-filename="format-system lader" data-name="Format-System (Basic Lader)" data-checksummer="2"></pre>
             <figcaption>Listing 2. Der DATA-Lader der Formatierroutine</figcaption>
         </figure>
 

--- a/issues/8505/159 Effektives Programmieren (5)_ Sortieren in Basic — Teil 2.html
+++ b/issues/8505/159 Effektives Programmieren (5)_ Sortieren in Basic — Teil 2.html
@@ -142,15 +142,15 @@
         <address class="author">(Karsten Schramm/gk)</address>
 
         <figure>
-            <pre data-filename="bubblesort" data-name="Bubblesort"></pre>
+            <pre data-filename="bubblesort" data-name="Bubblesort" data-checksummer="2"></pre>
             <figcaption>Listing 1. Der verbesserte Bubblesort-Algorithmus</figcaption>
         </figure>
         <figure>
-            <pre data-filename="str.selection" data-name="straight selection"></pre>
+            <pre data-filename="str.selection" data-name="straight selection" data-checksummer="2"></pre>
             <figcaption>Listing 2. Sortieren durch direktes Auswählen: straight selection</figcaption>
         </figure>
         <figure>
-            <pre data-filename="shellsort" data-name="Shellsort"></pre>
+            <pre data-filename="shellsort" data-name="Shellsort" data-checksummer="2"></pre>
             <figcaption>Listing 3. Der Shellsort-Algorithmus. Ab Zeile 20000 wird die straight-insertion-Methode benutzt, um die Untereinheiten zu sortieren. Auch hier näheres im Artikel.</figcaption>
         </figure>
 

--- a/issues/8505/173 VIC — Das »intelligente« Programm.html
+++ b/issues/8505/173 VIC — Das »intelligente« Programm.html
@@ -188,7 +188,7 @@
             </ul>         
             <figcaption>Tabelle 2. »VIC«-Schlüsselwörter</figcaption></figure>
         <figure>
-            <pre data-filename="vic" data-name="VIC"></pre>
+            <pre data-filename="vic" data-name="VIC" data-checksummer="2"></pre>
             <figcaption>Listing »VIC« — Das »intelligente« Programm</figcaption>
         </figure>
     </article>

--- a/issues/8505/30 Der MPS 802 lernt deutsch.html
+++ b/issues/8505/30 Der MPS 802 lernt deutsch.html
@@ -78,11 +78,11 @@
         <address class="author">(Ernst Schöberl/Arnd Wängler/gk)</address>
 
         <figure>
-            <pre data-filename="mps802.listing1" data-name="Deutscher Zeichensatz für MPS 802"></pre>
+            <pre data-filename="mps802.listing1" data-name="Deutscher Zeichensatz für MPS 802" data-checksummer="2"></pre>
             <figcaption>Listing I. Umrüsten des MPS 802 auf den deutschen Zeichensatz</figcaption>
         </figure>
         <figure>
-            <pre data-filename="mps802.listing2" data-name="Anpassung der Prüfsummen"></pre>
+            <pre data-filename="mps802.listing2" data-name="Anpassung der Prüfsummen" data-checksummer="2"></pre>
             <figcaption>Listing 2. Anpassung der Prüfsummen</figcaption>
         </figure>
     </article>

--- a/issues/8505/51 Trickfilm mit dem C 64.html
+++ b/issues/8505/51 Trickfilm mit dem C 64.html
@@ -202,7 +202,7 @@
             <figcaption>Listing »TRICK.OBJ«. Verwenden Sie bitte zur Eingabe den MSE</figcaption>
         </figure>
         <figure>
-            <pre data-filename="3d-movie-maker" data-name="3D-Movie-Maker"></pre>
+            <pre data-filename="3d-movie-maker" data-name="3D-Movie-Maker" data-checksummer="2"></pre>
             <figcaption>Listing »3D-Movie-Maker«. Beachten Sie bitte bei der Eingabe den Checksummer 64.</figcaption>
         </figure>
 

--- a/issues/8505/54 Checksummer 64.html
+++ b/issues/8505/54 Checksummer 64.html
@@ -192,7 +192,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="checksum.schnell" data-name="XXXXXXXXXXXX"></pre>
+            <pre data-filename="checksum.schnell" data-name="XXXXXXXXXXXX" data-checksummer="2"></pre>
             <figcaption>Der Checksummer für den C 64</figcaption>
         </figure>
     </article>

--- a/issues/8505/55 MSE-Abtippen sicher und leicht gemacht.html
+++ b/issues/8505/55 MSE-Abtippen sicher und leicht gemacht.html
@@ -76,7 +76,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="mse lader" data-name="MSE Lader"></pre>
+            <pre data-filename="mse lader" data-name="MSE Lader" data-checksummer="2"></pre>
             <figcaption>Der MSE zum bequemen Abtippen von Assemblerprogrammen</figcaption>
         </figure>
         <div class="binary_download" data-filename="mse v1.0.prg" data-name="MSE V1.0"></div>

--- a/issues/8505/69 Mini-Grafik VC 20.html
+++ b/issues/8505/69 Mini-Grafik VC 20.html
@@ -43,11 +43,11 @@
         <address class="author">(Wolfgang Wirth/ev)</address>
 
         <figure>
-            <pre data-filename="minigrafik" data-name="Mini-Grafik VC 20"></pre>
+            <pre data-filename="minigrafik" data-name="Mini-Grafik VC 20" data-checksummer="2"></pre>
             <figcaption>Listing 1. »Mini-Grafik VC 20« (Basic-Lader)</figcaption>
         </figure>
         <figure>
-            <pre data-filename="minigrafik demo" data-name="Mini-Grafik Demo"></pre>
+            <pre data-filename="minigrafik demo" data-name="Mini-Grafik Demo" data-checksummer="2"></pre>
             <figcaption>Listing 2. Demo-Programm zur »Mini-Grafik«</figcaption>
         </figure>
     </article>

--- a/issues/8505/70 6510 — Die Suche nach dem Prozessor.html
+++ b/issues/8505/70 6510 — Die Suche nach dem Prozessor.html
@@ -411,7 +411,7 @@
 
 
         <figure>
-            <pre data-filename="6510 i" data-name="6510"></pre>
+            <pre data-filename="6510 i" data-name="6510" data-checksummer="2"></pre>
             <figcaption>Listing »6510«. Beachten Sie den Checksummer 64</figcaption>
         </figure>
     </article>

--- a/issues/8505/77 Ordnung ist das halbe Leben.html
+++ b/issues/8505/77 Ordnung ist das halbe Leben.html
@@ -46,7 +46,7 @@
         <address class="author">(Edwin Göbel/hm)</address>
 
         <figure>
-            <pre data-filename="directory-sorter" data-name="Directory-Sorter"></pre>
+            <pre data-filename="directory-sorter" data-name="Directory-Sorter" data-checksummer="2"></pre>
             <figcaption>Listing zum Directory-Sorter. Beachten Sie den Checksummer auf Seite 54.</figcaption>
         </figure>
     </article>

--- a/issues/8505/83 Longscreen VC 20.html
+++ b/issues/8505/83 Longscreen VC 20.html
@@ -117,7 +117,7 @@
         <address class="author">(Wolfgang W. Wirth/ev)</address>
 
         <figure>
-            <pre data-filename="longscreen" data-name="Longscreen"></pre>
+            <pre data-filename="longscreen" data-name="Longscreen" data-checksummer="2"></pre>
             <figcaption>Listing »Longscreen« für den VC 20.</figcaption>
         </figure>
 

--- a/issues/8506/116 In die Geheimnisse der Floppy eingetaucht (Teil 7).html
+++ b/issues/8506/116 In die Geheimnisse der Floppy eingetaucht (Teil 7).html
@@ -258,11 +258,11 @@
         <address class="author">(Karsten Schramm/hm)</address>
 
         <figure>
-            <pre data-filename="gcr-hex" data-name="GCR nach Hex"></pre>
+            <pre data-filename="gcr-hex" data-name="GCR nach Hex" data-checksummer="2"></pre>
             <figcaption>Listing 1. Umwandlung von Daten in GCR-Bytes</figcaption>
         </figure>
         <figure>
-            <pre data-filename="hex-gcr" data-name="Hex nach GCR"></pre>
+            <pre data-filename="hex-gcr" data-name="Hex nach GCR" data-checksummer="2"></pre>
             <figcaption>Listing 2. Umwandlung von GCR- in Daten-Bytes</figcaption>
         </figure>
         <figure>

--- a/issues/8506/124 Effektives Programmieren (6)_ Sortieren mit dem Computer — (Teil 3).html
+++ b/issues/8506/124 Effektives Programmieren (6)_ Sortieren mit dem Computer — (Teil 3).html
@@ -93,7 +93,7 @@
         <address class="author">(Karsten Schramm/gk)</address>
 
         <figure>
-            <pre data-filename="heapsort" data-name="Heapsort"></pre>
+            <pre data-filename="heapsort" data-name="Heapsort" data-checksummer="2"></pre>
             <figcaption>Listing 1. Das Programm zum Heapsort (Sortieren mit Baumstruktur)</figcaption>
         </figure>
     </article>

--- a/issues/8506/155 »Dokumentationshilfe«_ Cross-Referenz-Liste C 64.html
+++ b/issues/8506/155 »Dokumentationshilfe«_ Cross-Referenz-Liste C 64.html
@@ -450,15 +450,15 @@
             <figcaption>Listing 1. Dieses Programm liefert die Listen Bild 3 bis 5.</figcaption>
         </figure>
         <figure>
-            <pre data-filename="crossreferenz" data-name="Cross-Referenz-Liste 64"></pre>
+            <pre data-filename="crossreferenz" data-name="Cross-Referenz-Liste 64" data-checksummer="2"></pre>
             <figcaption>Listing 2. Cross-Referenz-Liste 64</figcaption>
         </figure>
         <figure>
-            <pre data-filename="crossr andere" data-name="Cross-Ref 64 für andere Commodore-Computer"></pre>
+            <pre data-filename="crossr andere" data-name="Cross-Ref 64 für andere Commodore-Computer" data-checksummer="2"></pre>
             <figcaption>Listing 3. Cross-Ref 64 für andere Commodore-Computer</figcaption>
         </figure>
         <figure>
-            <pre data-filename="crossr datast" data-name="Cross-Ref 64 Anpassung an Datasette"></pre>
+            <pre data-filename="crossr datast" data-name="Cross-Ref 64 Anpassung an Datasette" data-checksummer="2"></pre>
             <figcaption>Listing 4. Anpassung von Cross-Ref 64 an die Datasette</figcaption>
         </figure>
     </article>

--- a/issues/8506/52 Die Scroll-Machine_ Das Fenster zur Spielewelt.html
+++ b/issues/8506/52 Die Scroll-Machine_ Das Fenster zur Spielewelt.html
@@ -642,7 +642,7 @@
             <figcaption>Listing 1. Hauptprogramm »Scroll-Machine«. Das Programm ist mit dem MSE einzugeben.</figcaption>
         </figure>
         <figure>
-            <pre data-filename="scroll-editor" data-name="Scroll-Machine Editor"></pre>
+            <pre data-filename="scroll-editor" data-name="Scroll-Machine Editor" data-checksummer="2"></pre>
             <figcaption>Listing 2. Editor »Scroll-Machine«. Zur sicheren Eingabe verwenden Sie bitte den Checksummer.</figcaption>
         </figure>
 
@@ -655,7 +655,7 @@
         <div class="binary_download" data-filename="pseudo ii.prg" data-name="Pseudo II"></div>
 
         <figure>
-            <pre data-filename="spiel" data-name="Spiel als Demoprogramm"></pre>
+            <pre data-filename="spiel" data-name="Spiel als Demoprogramm" data-checksummer="2"></pre>
             <figcaption>Listing 3. Ein kleines Spiel als Demoprogramm</figcaption>
         </figure>
 

--- a/issues/8506/54 MSE-Abtippen sicher und leicht gemacht.html
+++ b/issues/8506/54 MSE-Abtippen sicher und leicht gemacht.html
@@ -77,7 +77,7 @@
         </aside>
 
         <figure>
-            <pre data-filename="mse lader" data-name="MSE Lader"></pre>
+            <pre data-filename="mse lader" data-name="MSE Lader" data-checksummer="2"></pre>
             <figcaption>Der MSE zum bequemen Abtippen von Assemblerprogrammen</figcaption>
         </figure>
         <div class="binary_download" data-filename="mse v1.0.prg" data-name="MSE V1.0"></div>

--- a/issues/8506/72 Samurai.html
+++ b/issues/8506/72 Samurai.html
@@ -80,7 +80,7 @@
         <address class="author">(Thomas Strigl/rg)</address>
 
         <figure>
-            <pre data-filename="samurai" data-name="Samurai"></pre>
+            <pre data-filename="samurai" data-name="Samurai" data-checksummer="2"></pre>
             <figcaption>Listing »Samurai«. Geben Sie dieses Listing bitte mit dem Checksummer 64 ein.</figcaption>
         </figure>
     </article>

--- a/issues/8506/76 Prost mit dem C 64.html
+++ b/issues/8506/76 Prost mit dem C 64.html
@@ -103,7 +103,7 @@
             <figcaption>Liste der wichtigsten Variablen</figcaption>
         </figure>
         <figure>
-            <pre data-filename="prost" data-name="Pro.St"></pre>
+            <pre data-filename="prost" data-name="Pro.St" data-checksummer="2"></pre>
             <figcaption>Listing zu Pro.St</figcaption>
         </figure>
         <div class="binary_download" data-filename="upd.49309.prg" data-name="XXXXXXXXXXXXXXX"></div>

--- a/issues/8507/132 Dem Klang auf der Spur (Teil 7).html
+++ b/issues/8507/132 Dem Klang auf der Spur (Teil 7).html
@@ -504,7 +504,7 @@
         </figure>
     </article>
     <figure>
-        <pre data-filename="sound editor" data-name="Sound-Editor"></pre>
+        <pre data-filename="sound editor" data-name="Sound-Editor" data-checksummer="2"></pre>
         <figcaption>Listing »Sound-Editor«</figcaption>
     </figure>
 </body>

--- a/issues/8507/143 Logeleien (Teil 1).html
+++ b/issues/8507/143 Logeleien (Teil 1).html
@@ -432,11 +432,11 @@
             </figure>
         </aside>
         <figure>
-            <pre data-filename="logik-1" data-name="Logik-1"></pre>
+            <pre data-filename="logik-1" data-name="Logik-1" data-checksummer="2"></pre>
             <figcaption>Programm Logik-1. Mit NOT eine Geheimschrift erzeugen</figcaption>
         </figure>
         <figure>
-            <pre data-filename="logik-2" data-name="Logik-2"></pre>
+            <pre data-filename="logik-2" data-name="Logik-2" data-checksummer="2"></pre>
             <figcaption>Programm Logik-2. Sie sehen, was bei der Verknüpfung von Zahlen mit logischen Operatoren geschieht.</figcaption>
         </figure>
     </article>

--- a/issues/8507/149 Terminalprogramm der Spitzenklasse.html
+++ b/issues/8507/149 Terminalprogramm der Spitzenklasse.html
@@ -129,15 +129,15 @@
 
         <address class="author">(rg)</address>
         <figure>
-            <pre data-filename="lader.terminal" data-name="Lader"></pre>
+            <pre data-filename="lader.terminal" data-name="Lader" data-checksummer="2"></pre>
             <figcaption>Listing »Lader«.</figcaption>
         </figure>
         <figure>
-            <pre data-filename="bas.editor" data-name="Editor"></pre>
+            <pre data-filename="bas.editor" data-name="Editor" data-checksummer="2"></pre>
             <figcaption>Listing »Editor«.</figcaption>
         </figure>
         <figure>
-            <pre data-filename="bas.terminal" data-name="Terminal"></pre>
+            <pre data-filename="bas.terminal" data-name="Terminal" data-checksummer="2"></pre>
             <figcaption>Listing »Terminal«.</figcaption>
         </figure>
         <div class="binary_download" data-filename="editor.prg" data-name="Editor (compiliert)"></div>

--- a/issues/8507/44 Auf zu neuen Welten.html
+++ b/issues/8507/44 Auf zu neuen Welten.html
@@ -298,7 +298,7 @@
         <address class="author">(Ernst Schöberl/Arnd Wängler/ah)</address>
 
         <figure>
-            <pre data-filename="ieee basic" data-name="IEEE Basic"></pre>
+            <pre data-filename="ieee basic" data-name="IEEE Basic" data-checksummer="2"></pre>
             <figcaption>Listing 1. Treibersoftware für das IEEE-488-Interface.</figcaption>
         </figure>
         <div class="binary_download" data-filename="rom ieee.$3.prg" data-name="ROM IEEE $3"></div>

--- a/issues/8507/52 Damit Sie wissen, was Sie ausgeben.html
+++ b/issues/8507/52 Damit Sie wissen, was Sie ausgeben.html
@@ -414,7 +414,7 @@
             <figcaption>Tabelle 1. Die wichtigsten Variablen</figcaption>
         </figure>
         <figure>
-            <pre data-filename="haushaltsbuch" data-name="Haushaltsbuch"></pre>
+            <pre data-filename="haushaltsbuch" data-name="Haushaltsbuch" data-checksummer="2"></pre>
             <figcaption>Das Haushaltsbuch</figcaption>
         </figure>
         <div class="binary_download" data-filename="1985haushalt.tes.seq" data-name="1985 Haushaltsbuch Test"></div>

--- a/issues/8507/77 Komfortable Ein-_Ausgaberoutine.html
+++ b/issues/8507/77 Komfortable Ein-_Ausgaberoutine.html
@@ -41,7 +41,7 @@
 
         <address class="author">(Jürgen Hamader/ah)</address>
         <figure>
-            <pre data-filename="ein-ausgabe bl" data-name="Ein-/Ausgaberoutine"></pre>
+            <pre data-filename="ein-ausgabe bl" data-name="Ein-/Ausgaberoutine" data-checksummer="2"></pre>
             <figcaption>Listing »Ein-/Ausgaberoutine«</figcaption>
         </figure>
     </article>

--- a/issues/8507/78 Centronics-Interface für jeden Bedarf.html
+++ b/issues/8507/78 Centronics-Interface für jeden Bedarf.html
@@ -314,19 +314,19 @@
 
         <address class="author">(W. Forstenrath, M. Braun, A. Wängler/hm)</address>
         <figure>
-            <pre data-filename="cent.listing1" data-name="cent.listing1"></pre>
+            <pre data-filename="cent.listing1" data-name="cent.listing1" data-checksummer="2"></pre>
             <figcaption>Listing 1. »C 64 Centron«. Kernal-Centronics-Schnittstelle ohne Funktionsverlust.</figcaption>
         </figure>
         <figure>
-            <pre data-filename="cent.listing2" data-name="cent.listing2"></pre>
+            <pre data-filename="cent.listing2" data-name="cent.listing2" data-checksummer="2"></pre>
             <figcaption>Listing 2. Beispiel zur benutzerdefinierten Schnittstelle in »C 64 Centron«</figcaption>
         </figure>
         <figure>
-            <pre data-filename="cent.listing3" data-name="cent.listing3"></pre>
+            <pre data-filename="cent.listing3" data-name="cent.listing3" data-checksummer="2"></pre>
             <figcaption>Listing 3. Centronics-Schnittstelle in Hypra-Perfekt eingebunden</figcaption>
         </figure>
         <figure>
-            <pre data-filename="cent.listing4" data-name="cent.listing4"></pre>
+            <pre data-filename="cent.listing4" data-name="cent.listing4" data-checksummer="2"></pre>
             <figcaption>Listing 4. Eine frei verschiebbare Centronics-Schnittstelle als Softwarelösung</figcaption>
         </figure>
     </article>

--- a/issues/8507/83 Elektronischer Merkzettel.html
+++ b/issues/8507/83 Elektronischer Merkzettel.html
@@ -24,7 +24,7 @@
 
         <address class="author">(Georg Kramer/ah)</address>
         <figure>
-            <pre data-filename="merk-zettel v2.0" data-name="Merk-Zettel"></pre>
+            <pre data-filename="merk-zettel v2.0" data-name="Merk-Zettel" data-checksummer="2"></pre>
             <figcaption>Listing »Merk-Zettel« für den C 64.</figcaption>
         </figure>
     </article>

--- a/issues/8507/85 Tips und Tricks.html
+++ b/issues/8507/85 Tips und Tricks.html
@@ -143,7 +143,7 @@
         <address class="author">(Henning Zipf)</address>
 
         <figure>
-            <pre data-filename="reset-helfer" data-name="Reset-Helfer"></pre>
+            <pre data-filename="reset-helfer" data-name="Reset-Helfer" data-checksummer="2"></pre>
             <figcaption>Listing »Reset-Helfer« für den C 64</figcaption>
         </figure>
 

--- a/issues/SH8501/18 Ein besonderer Disassembler.html
+++ b/issues/SH8501/18 Ein besonderer Disassembler.html
@@ -53,7 +53,7 @@
         <address class="author">(Stefan Heine / ev)</address>
 
         <figure>
-            <pre data-filename="disassembler" data-name="Dezimal-Disassembler"></pre>
+            <pre data-filename="disassembler" data-name="Dezimal-Disassembler" data-checksummer="1"></pre>
         </figure>
 
     </article>

--- a/issues/SH8501/19 Mouse 64.html
+++ b/issues/SH8501/19 Mouse 64.html
@@ -73,7 +73,7 @@
         <address class="author">(Peter Dreuw / rg)</address>
 
         <figure>
-            <pre data-filename="mouse 64" data-name="Mouse 64"></pre>
+            <pre data-filename="mouse 64" data-name="Mouse 64" data-checksummer="1"></pre>
             <figcaption>Listing 1. Der Basic-Lader der «Mouse 64«</figcaption>
         </figure>
 

--- a/issues/SH8501/22 17 Super-Utilities für den C64.html
+++ b/issues/SH8501/22 17 Super-Utilities für den C64.html
@@ -170,7 +170,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="hilfsroutinen" data-name="Super-Utilities"></pre>
+            <pre data-filename="hilfsroutinen" data-name="Super-Utilities" data-checksummer="1"></pre>
             <figcaption>Listing »Super-Utilities«</figcaption>
         </figure>
 

--- a/issues/SH8501/30 »Windows« für den C 64.html
+++ b/issues/SH8501/30 »Windows« für den C 64.html
@@ -80,7 +80,7 @@
         <address class="author">(Hans-Herbert Hagedorn / ev)</address>
 
         <figure>
-            <pre data-filename="bildspeicher" data-name="Bildspeicher"></pre>
+            <pre data-filename="bildspeicher" data-name="Bildspeicher" data-checksummer="1"></pre>
             <figcaption>Listing «Bildspeicher«</figcaption>
         </figure>
 

--- a/issues/SH8501/32 DATA-Erzeuger.html
+++ b/issues/SH8501/32 DATA-Erzeuger.html
@@ -135,7 +135,7 @@
         <address class="author">(Jörg Materna / ev)</address>
 
         <figure>
-            <pre data-filename="data erzeuger" data-name="DATA-Erzeuger"></pre>
+            <pre data-filename="data erzeuger" data-name="DATA-Erzeuger" data-checksummer="1"></pre>
         </figure>
 
     </article>

--- a/issues/SH8501/34 Single-Step für VC 20.html
+++ b/issues/SH8501/34 Single-Step für VC 20.html
@@ -49,7 +49,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="single step" data-name="Single-Step"></pre>
+            <pre data-filename="single step" data-name="Single-Step" data-checksummer="1"></pre>
         </figure>
 
     </article>

--- a/issues/SH8501/36 Disksorter in Vollendung.html
+++ b/issues/SH8501/36 Disksorter in Vollendung.html
@@ -86,7 +86,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="disksorter basic" data-name="Disksorter (Basic)"></pre>
+            <pre data-filename="disksorter basic" data-name="Disksorter (Basic)" data-checksummer="1"></pre>
         </figure>
         <div class="binary_download" data-filename="disksorter.prg" data-name="Disksorter (compiliert)"></div>
 

--- a/issues/SH8501/4 Checksummer — keine Fehler mehr beim Abtippen von Listings.html
+++ b/issues/SH8501/4 Checksummer — keine Fehler mehr beim Abtippen von Listings.html
@@ -247,10 +247,10 @@
         <address class="author">(F. Lonczewski / gk)</address>
 
         <figure>
-            <pre data-filename="checksummer 64" data-name="Checksummer 64"></pre>
+            <pre data-filename="checksummer 64" data-name="Checksummer 64" data-checksummer="1"></pre>
         </figure>
         <figure>
-            <pre data-filename="checksummer vc20" data-name="Checksummer VC 20"></pre>
+            <pre data-filename="checksummer vc20" data-name="Checksummer VC 20" data-checksummer="1"></pre>
         </figure>
 
     </article>

--- a/issues/SH8501/44 ESF- Editieren sequentieller Dateien.html
+++ b/issues/SH8501/44 ESF- Editieren sequentieller Dateien.html
@@ -59,7 +59,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="edit seq-file" data-name="Edit SEQ-File"></pre>
+            <pre data-filename="edit seq-file" data-name="Edit SEQ-File" data-checksummer="1"></pre>
         </figure>
 
     </article>

--- a/issues/SH8501/46 Track 18 — Das Chaos organisieren.html
+++ b/issues/SH8501/46 Track 18 — Das Chaos organisieren.html
@@ -143,7 +143,7 @@
         <address class="author">(Andreas Kölbach / ev)</address>
 
         <figure>
-            <pre data-filename="track 18" data-name="Track 18"></pre>
+            <pre data-filename="track 18" data-name="Track 18" data-checksummer="1"></pre>
         </figure>
 
         <aside class="fehlerteufelchen" id="fehlerteufelchen">

--- a/issues/SH8501/51 Disketten-Meister.html
+++ b/issues/SH8501/51 Disketten-Meister.html
@@ -242,11 +242,11 @@
         </figure>
 
         <figure>
-            <pre data-filename="lader_disk-maste" data-name="Disk-Master (Basic-Lader)"></pre>
+            <pre data-filename="lader_disk-maste" data-name="Disk-Master (Basic-Lader)" data-checksummer="1"></pre>
         </figure>
         <div class="binary_download" data-filename="disk-master_m.prg" data-name="Disk-Master (Maschinencode)"></div>
         <figure>
-            <pre data-filename="disk-master" data-name="Disk-Master (DATAs)"></pre>
+            <pre data-filename="disk-master" data-name="Disk-Master (DATAs)" data-checksummer="1"></pre>
         </figure>
 
         <aside class="fehlerteufelchen" id="fehlerteufelchen">

--- a/issues/SH8501/54 Fileprotect 64.html
+++ b/issues/SH8501/54 Fileprotect 64.html
@@ -152,7 +152,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="fileprotect" data-name="Fileprotect"></pre>
+            <pre data-filename="fileprotect" data-name="Fileprotect" data-checksummer="1"></pre>
         </figure>
 
         <aside class="fehlerteufelchen" id="fehlerteufelchen">

--- a/issues/SH8501/62 P-Basic-V2- Autostart mit Rückwärtsgang.html
+++ b/issues/SH8501/62 P-Basic-V2- Autostart mit Rückwärtsgang.html
@@ -57,7 +57,7 @@
         <address class="author">(Jan Kusch/gk)</address>
 
         <figure>
-            <pre data-filename="autostart-64" data-name="P-Basic-V2"></pre>
+            <pre data-filename="autostart-64" data-name="P-Basic-V2" data-checksummer="1"></pre>
         </figure>
         <figure>
             <pre>  100 sys9*4096 : .opt oo

--- a/issues/SH8501/67 Toolkit für Programmierer.html
+++ b/issues/SH8501/67 Toolkit für Programmierer.html
@@ -81,7 +81,7 @@
         <address class="author">(Herbert Kunz / gk)</address>
 
         <figure>
-            <pre data-filename="tool-kit_kunz" data-name="Toolkit"></pre>
+            <pre data-filename="tool-kit_kunz" data-name="Toolkit" data-checksummer="1"></pre>
             <figcaption>Bild 1. Der Basic-Lader erzeugt das Toolkit. Speichern Sie dieses Programm sicherheitshalber vor dem RUN ab. Nach dem Start benutzen Sie das Programm in Bild 2, um den Maschinencode zu speichern.</figcaption>
         </figure>
         <figure>

--- a/issues/SH8501/7 M-P-S- Multi-Programm-System – Mehr als 30 Programme gleichzeitig im Speicher.html
+++ b/issues/SH8501/7 M-P-S- Multi-Programm-System – Mehr als 30 Programme gleichzeitig im Speicher.html
@@ -127,7 +127,7 @@
         <address class="author">(Kasem Mossavi / gk)</address>
 
         <figure>
-            <pre data-filename="m-p-s" data-name="Multi-Programm-System"></pre>
+            <pre data-filename="m-p-s" data-name="Multi-Programm-System" data-checksummer="1"></pre>
         </figure>
 
     </article>

--- a/issues/SH8501/70 Eigene Basic-Befehle auf dem C 64.html
+++ b/issues/SH8501/70 Eigene Basic-Befehle auf dem C 64.html
@@ -28,7 +28,7 @@
         <address class="author">(Förtsch / rg)</address>
 
         <figure>
-            <pre data-filename="eigenes basic" data-name="Befehlserweiterung"></pre>
+            <pre data-filename="eigenes basic" data-name="Befehlserweiterung" data-checksummer="1"></pre>
         </figure>
 
     </article>

--- a/issues/SH8501/72 Basic auf Tastendruck.html
+++ b/issues/SH8501/72 Basic auf Tastendruck.html
@@ -358,7 +358,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="tastendruck" data-name="KEYS"></pre>
+            <pre data-filename="tastendruck" data-name="KEYS" data-checksummer="1"></pre>
         </figure>
 
     </article>

--- a/issues/SH8501/74 Automatische Zeilennumerierung.html
+++ b/issues/SH8501/74 Automatische Zeilennumerierung.html
@@ -32,7 +32,7 @@
         <address class="author">(Thomas Schulz/rg)</address>
 
         <figure>
-            <!-- <pre data-filename="Xutonum 64" data-name="Xutonum 64"></pre> -->
+            <!-- <pre data-filename="Autonum 64" data-name="Autonum 64" data-checksummer="1"></pre> -->
         </figure>
 
     </article>

--- a/issues/SH8501/74 Worktool — eine Programmierhilfe.html
+++ b/issues/SH8501/74 Worktool — eine Programmierhilfe.html
@@ -139,7 +139,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="worktool" data-name="Worktool"></pre>
+            <pre data-filename="worktool" data-name="Worktool" data-checksummer="1"></pre>
         </figure>
 
     </article>

--- a/issues/SH8501/78 Mini-GBasic für den VC 20.html
+++ b/issues/SH8501/78 Mini-GBasic für den VC 20.html
@@ -176,7 +176,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="mini gbasic" data-name="Mini-GBasic"></pre>
+            <pre data-filename="mini gbasic" data-name="Mini-GBasic" data-checksummer="1"></pre>
         </figure>
 
     </article>

--- a/issues/SH8501/83 Commodore-Basic erweitert.html
+++ b/issues/SH8501/83 Commodore-Basic erweitert.html
@@ -65,15 +65,15 @@
         <address class="author">(Wolfgang Thauer / ev)</address>
 
         <figure>
-            <pre data-filename="ver.lader vc 20" data-name="6 neue Befehle VC 20 (Basic-Lader)"></pre>
+            <pre data-filename="ver.lader vc 20" data-name="6 neue Befehle VC 20 (Basic-Lader)" data-checksummer="1"></pre>
             <figcaption>Listing 1. Basic-Lader »6 neue Befehle« (VC 20-Version)</figcaption>
         </figure>
         <figure>
-            <pre data-filename="ver.lader c 64" data-name="6 neue Befehle C 64 (Basic-Lader)"></pre>
+            <pre data-filename="ver.lader c 64" data-name="6 neue Befehle C 64 (Basic-Lader)" data-checksummer="1"></pre>
             <figcaption>Listing 2. Basic-Lader »6 neue Befehle« (C 64-Version)</figcaption>
         </figure>
         <figure>
-            <pre data-filename="verschieber" data-name="Adressen-Umrechner"></pre>
+            <pre data-filename="verschieber" data-name="Adressen-Umrechner" data-checksummer="1"></pre>
             <figcaption>Listing 3. Der Adressen-Umrechner</figcaption>
         </figure>
 

--- a/issues/SH8501/83 Delete.html
+++ b/issues/SH8501/83 Delete.html
@@ -38,7 +38,7 @@
         <address class="author">(Hans-Herbert Hagedorn / ev)</address>
 
         <figure>
-            <pre data-filename="delete" data-name="Delete"></pre>
+            <pre data-filename="delete" data-name="Delete" data-checksummer="1"></pre>
         </figure>
 
     </article>

--- a/issues/SH8501/86 Hardcopy im Superformat.html
+++ b/issues/SH8501/86 Hardcopy im Superformat.html
@@ -40,7 +40,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="hardcopy fx80 " data-name="Super-Hardcopy"></pre>
+            <pre data-filename="hardcopy fx80 " data-name="Super-Hardcopy" data-checksummer="1"></pre>
             <figcaption>Listing »Super-Hardcopy«</figcaption>
         </figure>
 

--- a/issues/SH8501/88 Zeichen-Editor.html
+++ b/issues/SH8501/88 Zeichen-Editor.html
@@ -253,7 +253,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="zeichen-editor" data-name="Zeichen-Editor"></pre>
+            <pre data-filename="zeichen-editor" data-name="Zeichen-Editor" data-checksummer="1"></pre>
             <figcaption>Listing »Zeichen-Editor«</figcaption>
         </figure>
 

--- a/issues/SH8501/9 Dateiorganisation.html
+++ b/issues/SH8501/9 Dateiorganisation.html
@@ -513,7 +513,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="datei-organisati" data-name="Dateiorganisation"></pre>
+            <pre data-filename="datei-organisati" data-name="Dateiorganisation" data-checksummer="1"></pre>
         </figure>
 
 

--- a/issues/SH8501/91 Super Line — 80 Zeichen für den C 64.html
+++ b/issues/SH8501/91 Super Line — 80 Zeichen für den C 64.html
@@ -64,7 +64,7 @@
         <address class="author">(Andreas Zell / rg)</address>
 
         <figure>
-            <pre data-filename="super line" data-name="Super Line"></pre>
+            <pre data-filename="super line" data-name="Super Line" data-checksummer="1"></pre>
         </figure>
         <div class="binary_download" data-filename="super line demo.prg" data-name="Super Line Demo"></div>
 

--- a/issues/SH8501/93 Tastaturpieps.html
+++ b/issues/SH8501/93 Tastaturpieps.html
@@ -29,7 +29,7 @@
         <address class="author">(Wolfgang Roth / rg)</address>
 
         <figure>
-            <pre data-filename="tastaturpieps" data-name="Tastaturpieps"></pre>
+            <pre data-filename="tastaturpieps" data-name="Tastaturpieps" data-checksummer="1"></pre>
         </figure>
 
     </article>

--- a/issues/SH8502/102 Crantor — Bedrohung aus dem All.html
+++ b/issues/SH8502/102 Crantor — Bedrohung aus dem All.html
@@ -351,7 +351,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="crantor" data-name="Crantor"></pre>
+            <pre data-filename="crantor" data-name="Crantor" data-checksummer="2"></pre>
             <figcaption>Listing »Crantor«. Beachten Sie beim Eintippen bitte den Checksummer.</figcaption>
         </figure>
     </article>

--- a/issues/SH8502/111 Odyssee — Kampf der Bruderschaft.html
+++ b/issues/SH8502/111 Odyssee — Kampf der Bruderschaft.html
@@ -457,12 +457,12 @@
         </figure>
 
         <figure>
-            <pre data-filename="odyssee" data-name="Odyssee"></pre>
+            <pre data-filename="odyssee" data-name="Odyssee" data-checksummer="2"></pre>
             <figcaption>Listing »Odyssee«. Beachten Sie beim Abtippen bitte
                 den Checksummer.</figcaption>
         </figure>
         <figure>
-            <pre data-filename="creater" data-name="World-Creater"></pre>
+            <pre data-filename="creater" data-name="World-Creater" data-checksummer="2"></pre>
             <figcaption>Listing »World-Creater«</figcaption>
         </figure>
 

--- a/issues/SH8502/53 Zauberschloß  – ein Abenteuerspiel mit Tücken.html
+++ b/issues/SH8502/53 Zauberschloß  – ein Abenteuerspiel mit Tücken.html
@@ -376,7 +376,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="zauberschloss" data-name="Zauberschloß"></pre>
+            <pre data-filename="zauberschloss" data-name="Zauberschloß" data-checksummer="2"></pre>
             <figcaption>Listing »Zauberschloß«. Beachten Sie bitte den Checksummer.</figcaption>
         </figure>
 

--- a/issues/SH8502/63 Neuer Checksummer 64 — blitzschnell und kürzer.html
+++ b/issues/SH8502/63 Neuer Checksummer 64 — blitzschnell und kürzer.html
@@ -227,7 +227,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="checksum.schnell" data-name="Checksummer (C 64)"></pre>
+            <pre data-filename="checksum.schnell" data-name="Checksummer (C 64)" data-checksummer="2"></pre>
             <figcaption>Der Ckecksummer 64 zum Eintippen der Listings</figcaption>
         </figure>
 

--- a/issues/SH8502/65 Adventure 2000 — Die Jagd nach der Rakete.html
+++ b/issues/SH8502/65 Adventure 2000 — Die Jagd nach der Rakete.html
@@ -160,7 +160,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="adventure 2000" data-name="Adventure 2000"></pre>
+            <pre data-filename="adventure 2000" data-name="Adventure 2000" data-checksummer="2"></pre>
             <figcaption>Listing »Adventure 2000«. Beachten Sie bei der Eingabe bitte den Checksummer.</figcaption>
         </figure>
 

--- a/issues/SH8502/7 Abenteuer selbst programmiert.html
+++ b/issues/SH8502/7 Abenteuer selbst programmiert.html
@@ -791,7 +791,7 @@
         <p>a) Befehleingabe Modul 1<br>Geben Sie nun einmal Listing 1 in den Computer ein:</p>
 
         <figure>
-            <pre data-filename="listing 1" data-name="Listing 1"></pre>
+            <pre data-filename="listing 1" data-name="Listing 1" data-checksummer="2"></pre>
             <figcaption>Listing 1.</figcaption>
         </figure>
 
@@ -842,7 +842,7 @@
         <p>b) Befehlseingabe Modul 2<br>Geben Sie bitte das folgende Programm (Listing 2) ein und lassen Sie es nach SAVE laufen.</p>
 
         <figure>
-            <pre data-filename="listing 2" data-name="Listing 2"></pre>
+            <pre data-filename="listing 2" data-name="Listing 2" data-checksummer="2"></pre>
             <figcaption>Listing 2.</figcaption>
         </figure>
 
@@ -897,7 +897,7 @@
         <p>Nun möchte ich Ihnen noch eine Routine (Listing 3) vorstellen. Erfolgt 30 Sekunden lang keine Eingabe, so endet die Routine und fährt im Programm fort— die Bedenkzeit des Spielers wird also eingeschränkt. Bei dieser Routine werden Sie feststellen, daß der Bildschirm in zwei Abschnitte unterteilt ist, wie es bei Adventures mit Grafik und Text vorkommt. Die oberen 3/4 des Bildschirms sind als Grafik-Fenster, das untere Viertel als Texteingabe-Fenster definiert.</p>
 
         <figure>
-            <pre data-filename="listing 3" data-name="Listing 3"></pre>
+            <pre data-filename="listing 3" data-name="Listing 3" data-checksummer="2"></pre>
             <figcaption>Listing 3.</figcaption>
         </figure>
 
@@ -1505,7 +1505,7 @@
         <p>Bitte geben Sie nun einmal Listing 4 ein:</p>
 
         <figure>
-            <pre data-filename="listing 4" data-name="Listing 4"></pre>
+            <pre data-filename="listing 4" data-name="Listing 4" data-checksummer="2"></pre>
             <figcaption>Listing 4.</figcaption>
         </figure>
 
@@ -1572,7 +1572,7 @@
         <p>Der nächste Schritt zur Fertigstellung des Moduls besteht nun, wie bereits theoretisch behandelt, darin, überflüssige Worte auszusortieren, beziehungsweise erst gar nicht in die Wortkette BE$(1) bis BES(1 0) aufzunehmen. Wir müssen unser erstes Programm also entsprechend Listing 5 verbessern:</p>
          
         <figure>
-            <pre data-filename="listing 5" data-name="Listing 5"></pre>
+            <pre data-filename="listing 5" data-name="Listing 5" data-checksummer="2"></pre>
             <figcaption>Listing 5.</figcaption>
         </figure>
 
@@ -1911,7 +1911,7 @@
         <p>Geben Sie nun das Listing 6 der neuen Module ein, und versuchen Sie, es bereits beim Abtippen unter Zuhilfenahme der Variablentabelle zu verstehen.</p>
 
         <figure>
-            <pre data-filename="listing 6" data-name="Listing 6"></pre>
+            <pre data-filename="listing 6" data-name="Listing 6" data-checksummer="2"></pre>
             <figcaption>Listing 6.</figcaption>
         </figure>
 
@@ -2215,7 +2215,7 @@
         <p>Man könnte im Prinzip auch für die anderen Worttabellen, wie die Objekttabelle, Abkürzungen erlauben. Ich halte dies jedoch für überflüssig. Geben Sie nun bitte das Listing 7 ein und speichern Sie es auf Kassette oder Diskette ab, damit Sie in den folgenden Kapiteln darauf zurückgreifen können.</p>
          
         <figure>
-            <pre data-filename="listing 7" data-name="Listing 7"></pre>
+            <pre data-filename="listing 7" data-name="Listing 7" data-checksummer="2"></pre>
             <figcaption>Listing 7.</figcaption>
         </figure>
 
@@ -2254,7 +2254,7 @@
         <p>Bitte geben Sie das folgende Programm ein und speichern Sie es anschließend ab. Noch besser ist es, wenn Sie zuerst das Befehlseingabemodul, das Sie hoffentlich bereits abgetippt haben, laden, und es um das folgende Listing 8 ergänzen.</p>
          
         <figure>
-            <pre data-filename="listing 8" data-name="Listing 8"></pre>
+            <pre data-filename="listing 8" data-name="Listing 8" data-checksummer="2"></pre>
             <figcaption>Listing 8.</figcaption>
         </figure>
 
@@ -2368,7 +2368,7 @@
         <p>Geben Sie bitte wieder die Ergänzungszeilen aus Listing 9 ein:</p>
 
         <figure>
-            <pre data-filename="listing 9" data-name="Listing 9"></pre>
+            <pre data-filename="listing 9" data-name="Listing 9" data-checksummer="2"></pre>
             <figcaption>Listing 9.</figcaption>
         </figure>
 
@@ -2399,7 +2399,7 @@
         <p>Bitte ergänzen Sie Ihr bisheriges Programm (Basic - Erweiterungsroutine und Befehlseingabemodul) nun um die Zeilen von Listing 10.</p>
 
         <figure>
-            <pre data-filename="listing 10" data-name="Listing 10"></pre>
+            <pre data-filename="listing 10" data-name="Listing 10" data-checksummer="2"></pre>
             <figcaption>Listing 10.</figcaption>
         </figure>
 
@@ -2467,7 +2467,7 @@
         <p>Hiermit ist unser Ziel erreicht — Sie wissen nun, wie man eine Spielkarte programmiert.</p>
 
         <figure>
-            <pre data-filename="listing 11" data-name="Listing 11"></pre>
+            <pre data-filename="listing 11" data-name="Listing 11" data-checksummer="2"></pre>
             <figcaption>Listing 11.</figcaption>
         </figure>
 
@@ -2482,7 +2482,7 @@
         <p>Dies läßt sich ganz einfach realisieren, wenn man unser bisheriges Programm durch Listing 12 ergänzt:</p>
 
         <figure>
-            <pre data-filename="listing 12" data-name="Listing 12"></pre>
+            <pre data-filename="listing 12" data-name="Listing 12" data-checksummer="2"></pre>
             <figcaption>Listing 12.</figcaption>
         </figure>
 
@@ -2501,14 +2501,14 @@
         <p>Wir ergänzen unser Programm nun um Listing 13.</p>
 
         <figure>
-            <pre data-filename="listing 13" data-name="Listing 13"></pre>
+            <pre data-filename="listing 13" data-name="Listing 13" data-checksummer="2"></pre>
             <figcaption>Listing 13.</figcaption>
         </figure>
 
         <p>Bitte notieren Sie sich auch diese Tabelle auf Papier. In jeder DATA-Zeile dieser Tabelle steht zuerst der Name des Gegenstands, und danach eine Zahl, die angibt, in welchem Raum sich der Gegenstand befindet (Raumzahl: vergleiche Karte).</p>
 
         <figure>
-            <pre data-filename="listing 14" data-name="Listing 14"></pre>
+            <pre data-filename="listing 14" data-name="Listing 14" data-checksummer="2"></pre>
             <figcaption>Listing 14.</figcaption>
         </figure>
 
@@ -2521,7 +2521,7 @@
         <p>Die Objektnamen werden in OB$(1) bis OB$(OZ) untergebracht. Außerdem legen wir noch ein Feld OO(1) bis OO(OZ) an, in dem, analog zu den Gegenständen, gespeichert wird, wo sich die einzelnen Objekte befinden. Wir ergänzen durch Listing 15.</p>
 
         <figure>
-            <pre data-filename="listing 15" data-name="Listing 15"></pre>
+            <pre data-filename="listing 15" data-name="Listing 15" data-checksummer="2"></pre>
             <figcaption>Listing 15.</figcaption>
         </figure>
 
@@ -2532,7 +2532,7 @@
         <p>Ergänzen Sie bitte nun um Listing 16.</p>
 
         <figure>
-            <pre data-filename="listing 16" data-name="Listing 16"></pre>
+            <pre data-filename="listing 16" data-name="Listing 16" data-checksummer="2"></pre>
             <figcaption>Listing 16.</figcaption>
         </figure>
 
@@ -2549,7 +2549,7 @@
         <p>Wenn Sie bis jetzt richtig mitgearbeitet haben, so müssen Sie Listing 17 im Computer haben.</p>
 
         <figure>
-            <pre data-filename="listing 17" data-name="Listing 17"></pre>
+            <pre data-filename="listing 17" data-name="Listing 17" data-checksummer="2"></pre>
             <figcaption>Listing 17.</figcaption>
         </figure>
          
@@ -2641,7 +2641,7 @@
         <p>Wir ergänzen das Actionmodul um Listing 18.</p>
          
         <figure>
-            <pre data-filename="listing 18" data-name="Listing 18"></pre>
+            <pre data-filename="listing 18" data-name="Listing 18" data-checksummer="2"></pre>
             <figcaption>Listing 18.</figcaption>
         </figure>
 
@@ -2690,7 +2690,7 @@
         <p>Bitte ergänzen Sie das Adventure um Listing 19.</p>
 
         <figure>
-            <pre data-filename="listing 19" data-name="Listing 19"></pre>
+            <pre data-filename="listing 19" data-name="Listing 19" data-checksummer="2"></pre>
             <figcaption>Listing 19.</figcaption>
         </figure>
 
@@ -2701,7 +2701,7 @@
         <p>Die <strong>VERLIER-Routine</strong> ist in Listing 20 abgebildet.</p>
 
         <figure>
-            <pre data-filename="listing 20" data-name="Listing 20"></pre>
+            <pre data-filename="listing 20" data-name="Listing 20" data-checksummer="2"></pre>
             <figcaption>Listing 20.</figcaption>
         </figure>
 
@@ -2716,7 +2716,7 @@
         <p>Bitte ergänzen Sie durch Listing 21.</p>
 
         <figure>
-            <pre data-filename="listing 21" data-name="Listing 21"></pre>
+            <pre data-filename="listing 21" data-name="Listing 21" data-checksummer="2"></pre>
             <figcaption>Listing 21.</figcaption>
         </figure>
 
@@ -2733,7 +2733,7 @@
         <p>Dies lernen Sie alles im folgenden Abschnitt — die raumspezifische Action. Zunächst jedoch wieder ein Kontrollisting 22 zum Vergleich mit dem, was Sie momentan bei richtiger Mitarbeit vorliegen haben sollten.</p>
 
         <figure>
-            <pre data-filename="listing 22" data-name="Listing 22"></pre>
+            <pre data-filename="listing 22" data-name="Listing 22" data-checksummer="2"></pre>
             <figcaption>Listing 22.</figcaption>
         </figure>
 
@@ -2783,7 +2783,7 @@
         <p>Die raumspezifische Action wird immer am Ende des Actionmoduls aufgerufen. Ergänzen Sie Ihr Programm nun bitte um Listing 23.</p>
 
         <figure>
-            <pre data-filename="listing 23" data-name="Listing 23"></pre>
+            <pre data-filename="listing 23" data-name="Listing 23" data-checksummer="2"></pre>
             <figcaption>Listing 23.</figcaption>
         </figure>
 
@@ -2907,7 +2907,7 @@
         <p>Bitte ergänzen Sie mit Listing 24.</p>
 
         <figure>
-            <pre data-filename="listing 24" data-name="Listing 24"></pre>
+            <pre data-filename="listing 24" data-name="Listing 24" data-checksummer="2"></pre>
             <figcaption>Listing 24.</figcaption>
         </figure>
 
@@ -2950,7 +2950,7 @@
         <p>Dazu sind nur zwei neue Ergänzungszeilen aus Listing 25 notwendig.</p>
 
         <figure>
-            <pre data-filename="listing 25" data-name="Listing 25"></pre>
+            <pre data-filename="listing 25" data-name="Listing 25" data-checksummer="2"></pre>
             <figcaption>Listing 25.</figcaption>
         </figure>
 
@@ -3206,7 +3206,7 @@
         <p>Durch den Schacht gelangt man zu Raum 8. Dazu muß man das Seil am Eisenring befestigen und anschließend hinabklettern. Wenn Sie dieses Problem gelöst haben, können Sie sich durchaus daran machen, eigene Probleme zu stellen, und diese dann in Programmroutinen umzusetzen Hier noch abschließend Listing 26, das Sie vorliegen haben sollten, wenn Sie bisher richtig mitgearbeitet haben.</p>
 
         <figure>
-            <pre data-filename="listing 26" data-name="Listing 26"></pre>
+            <pre data-filename="listing 26" data-name="Listing 26" data-checksummer="2"></pre>
             <figcaption>Listing 26.</figcaption>
         </figure>
 
@@ -3227,7 +3227,7 @@
         <p>Das eigentlich mühselige Erstellen von Blockgrafiken wird so mit Listing 27 zum Kinderspiel.</p>
          
         <figure>
-            <pre data-filename="listing 27" data-name="Listing 27"></pre>
+            <pre data-filename="listing 27" data-name="Listing 27" data-checksummer="2"></pre>
             <figcaption>Listing 27.</figcaption>
         </figure>
 

--- a/issues/SH8502/76 Quasimodo, Herrscher der Kartanen.html
+++ b/issues/SH8502/76 Quasimodo, Herrscher der Kartanen.html
@@ -35,7 +35,7 @@
         <address class="author">(Roland Selzer/rg)</address>
 
         <figure>
-            <pre data-filename="quasimodo" data-name="Quasimodo"></pre>
+            <pre data-filename="quasimodo" data-name="Quasimodo" data-checksummer="2"></pre>
             <figcaption>Listing »Quasirnodo«</figcaption>
         </figure>
 

--- a/issues/SH8502/80 Mario, die unheimliche Mine.html
+++ b/issues/SH8502/80 Mario, die unheimliche Mine.html
@@ -508,7 +508,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="mario" data-name="Mario"></pre>
+            <pre data-filename="mario" data-name="Mario" data-checksummer="2"></pre>
             <figcaption>Listing »Mario«</figcaption>
         </figure>
     </article>

--- a/issues/SH8502/93 Zeittunnel — Flucht in die Gegenwart.html
+++ b/issues/SH8502/93 Zeittunnel — Flucht in die Gegenwart.html
@@ -129,7 +129,7 @@
         </figure>
 
         <figure>
-            <pre data-filename="zeittunnel" data-name="Zeittunnel"></pre>
+            <pre data-filename="zeittunnel" data-name="Zeittunnel" data-checksummer="2"></pre>
             <figcaption>Listing »Zeittunnel«</figcaption>
         </figure>
 


### PR DESCRIPTION
The first few issues weren't really consistent in adding checksums and this commit tracks it faithfully: no checksum in the magazine, no checksum on the website.