### PR TITLE
Fixup listings

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -701,6 +701,8 @@ class Issue:
                       content = content.replace("\ue000", "</span>")
                       listing_html += f"<span data-chksum='<{checksum:03d}>'>{lineno: 3d} {content} </span>\n"
                   listing = "\n".join(listing)
+                  listing = listing.replace("&", "&amp;")
+                  listing = listing.replace("<", "&lt;")
                   newhtml = f"""<div class="listing"><span class="controls"><input type="checkbox" role="switch" class="toggle" checked="checked" /></span>
                     <pre class="listing-petcat">{listing}</pre>
                     <pre class="listing-checksummer">{listing_html}</pre></div>

--- a/issues/style.css
+++ b/issues/style.css
@@ -1315,7 +1315,7 @@ pre.listing-petcat {
 	white-space: pre-wrap;
 }
 
-pre.listing-mse {
+[data-mse] {
 	columns: 40ch auto;
 }
 

--- a/tools/checksummer.py
+++ b/tools/checksummer.py
@@ -420,10 +420,10 @@ def parse(
                 if skip:
                     p += 1
                 if token in ["TO", "THEN"]:
-                    if line[-1] != " ":
+                    if line[-1] != 0x20:
                         line += " "
                 elif len(token) > 1 and token[:5] not in ["INPUT", "PRINT"]:
-                    if read8(p + 1) != " ":
+                    if read8(p + 1) != 0x20:
                         token += " "
                 line += token
 

--- a/tools/checksummer.py
+++ b/tools/checksummer.py
@@ -316,7 +316,7 @@ def detokenize(basicver: str, token: int, extratoken: int) -> (str, bool):
             tbl = tblit.__next__()
         except StopIteration:
             if "parent" not in langver:
-                return chr(token), False
+                return encoding_64er[token], False
             langver = tokens[langver["parent"]]
             tblit = iter(langver["segments"])
             tbl = tblit.__next__()


### PR DESCRIPTION
Fixes up various issues with rendering listings:

- petcat in the checksummer/petcat bundle wasn't HTML-escaped, now uses entities.
- checksummer listings had too many spaces in various places.
- special characters are now authentically 64er,
  e.g. instead of _, use ←, instead of \, use £
  (popular lead characters for Basic extensions)
- MSE listings are shown in multiple columns, too.