### PR TITLE
Fix "Dem Klang auf der Spur" numbering in index

### DIFF
--- a/Jahresinhaltsverzeichnis 1985.csv
+++ b/Jahresinhaltsverzeichnis 1985.csv
@@ -235,7 +235,7 @@
 8507,124,Software-Tests,Sprachen,Promal – die neue Sprache für Profis?
 8507,126,Software-Tests,Sprachen,Forth-wärts mit M&T-Forth 64
 8507,127,Kurse,Assembler,"Assembler ist keine Alchimie (Teil 10)"
-8507,132,Kurse,Musik,"Dem Klang auf der Spur (Teil 7)"
+8507,132,Kurse,Musik,"Dem Klang auf der Spur (Teil 6)"
 8507,140,Kurse,Speicher,"Memory Map mit Wandervorschlägen (Teil 8)"
 8507,143,Kurse,Logeleien,"Logeleien (Teil 1)"
 8507,149,Listings zum Abtippen,DFÜ,Terminalprogramm der Spitzenklasse
@@ -276,7 +276,7 @@
 8508,122,Software-Tests,Sprachen,Pascal für Profis (Profi-Pascal)
 8508,126,Kurse,Assembler,"Assembler ist keine Alchimie (Teil 11)"
 8508,129,Kurse,Speicher,"Memory Map mit Wandervorschlägen (Teil 9)"
-8508,133,Kurse,Musik,"Dem Klang auf der Spur (Teil 8)"
+8508,133,Kurse,Musik,"Dem Klang auf der Spur (Teil 7)"
 8508,136,Kurse,Logeleien,"Logeleien (Teil 2)"
 8508,138,Kurse,Effektives Programmieren,"Effektives Programmieren (Teil 7): Sortieren mit dem Computer (Teil 4)"
 8508,144,Kurse,Extern,"C 64 Extern – Der Weg nach draußen (Teil 1)"
@@ -346,7 +346,7 @@
 8510,86,Listings zum Abtippen,Tips & Tricks,Programmgenerator für den C 64
 8510,87,Listings zum Abtippen,Anwendungen,Neues vom SMON
 8510,92,64'er Extra,Grafik,Die Videochip-Register des C 64
-8510,126,Kurse,Musik,"Dem Klang auf der Spur (Teil 9)"
+8510,126,Kurse,Musik,"Dem Klang auf der Spur (Teil 8)"
 8510,129,Kurse,Extern,"C 64 Extern – Der Weg nach draußen (Teil 3; Schluß)"
 8510,133,Kurse,Speicher,"Memory Map mit Wandervorschlägen (Teil 11)"
 8510,143,Kurse,Assembler,"Assembler ist keine Alchimie (Teil 13; Schluß)"
@@ -387,7 +387,7 @@
 8511,112,Buchbesprechungen,DFÜ,Das Mailbox Jahrbuch: Nutz die Netze
 8511,145,Kurse,Speicher,"Memory Map mit Wandervorschlägen (Teil 12)"
 8511,149,Kurse,Grafik,"Streifzüge durch die Grafikwelt (Teil 2)"
-8511,157,Kurse,Musik,"Dem Klang auf der Spur (Teil 10; Schluß)"
+8511,157,Kurse,Musik,"Dem Klang auf der Spur (Teil 9; Schluß)"
 8511,162,Spiele-Tests,Pseudo Adventures,Fourth Protocol und Frankie goes to H.
 8511,165,Spiele-Tests,Sport,Handkantenschlag per Joystick: Karateka + Exploding Fist
 8511,171,Buchbesprechungen,Anfänger,C 64 Computerhandbuch

--- a/issues/8507/132 Dem Klang auf der Spur (Teil 7).html
+++ b/issues/8507/132 Dem Klang auf der Spur (Teil 7).html
@@ -2,7 +2,7 @@
 <html lang="de">
 
 <head>
-    <title>Dem Klang auf der Spur (Teil 7)</title>
+    <title>Dem Klang auf der Spur (Teil 7)</title> <!-- sic! but it's part 6 -->
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
     <meta name="author" content="Thomas Krätzig, ev">
@@ -10,9 +10,9 @@
     <meta name="64er.pages" content="132,134-136,139-140">
     <meta name="64er.head1" content="Musik-Kurs">
     <meta name="64er.head2" content="C 64">
-    <meta name="64er.toc_title" content="Dem Klang auf der Spur (Teil 7)">
+    <meta name="64er.toc_title" content="Dem Klang auf der Spur (Teil 7)" ><!-- sic! but it's part 6 -->
     <meta name="64er.toc_category" content="Kurse">
-    <meta name="64er.index_title" content="Dem Klang auf der Spur (Teil 7)">
+    <meta name="64er.index_title" content="Dem Klang auf der Spur (Teil 6)"> 
     <meta name="64er.index_category" content="Kurse|Musik">
     <meta name="64er.id" content="musik">
 </head>


### PR DESCRIPTION
"Dem Klang auf der Spur" numbering is a mess both in the printed issues and the index.

I'd suggest to fix the index and leave the issues as-is.