### PR TITLE
Consolidate "Hires 3" index entries

### DIFF
--- a/Jahresinhaltsverzeichnis 1985.csv
+++ b/Jahresinhaltsverzeichnis 1985.csv
@@ -55,7 +55,7 @@
 8502,90,Hardware-Tips und Bauanleitungen,Audio/Video,Besseres Monitorbild beim C 64
 8502,91,Listings zum Abtippen,Tips & Tricks,Maschinenspracheprogramme auf Disk speichern
 8502,92,Listings zum Abtippen,Tips & Tricks,RAM-Floppy
-8502,123,Kurse,Grafik,"Hires 3 – die Grafikerweiterung zum Grafikkurs (Teil 1)"
+8502,123,Kurse,Grafik,"Hires 3 (Teil 1): Die Grafikerweiterung zum Grafikkurs"
 8502,130,Kurse,Comal,"Comal – Eine Einführung (Teil 3)"
 8502,134,Kurse,Assembler,"Assembler ist keine Alchimie (Teil 6)"
 8502,141,Kurse,VC 20,"Der gläserne VC 20 (Teil 5)"
@@ -92,7 +92,7 @@
 8503,91,Software-Tips,Tips & Tricks,Verbindungsfreundlich (Parallelschnittstelle bei VC 20)
 8503,124,Kurse,Assembler,"Assembler ist keine Alchimie (Teil 7)"
 8503,130,Kurse,Floppy,"In die Geheimnisse der Floppy eingetaucht (Teil 5)"
-8503,136,Kurse,Grafik,"Hires 3 – 15 neue Basic-Befehle (Teil 2)"
+8503,136,Kurse,Grafik,"Hires 3 (Teil 2): 15 neue Basic-Befehle"
 8503,144,Kurse,Speicher,"Memory Map mit Wandervorschlägen (Teil 5)"
 8503,148,Kurse,Effektives Programmieren,"Effektives Programmieren (Teil 3): Finden mit System — Eine neuartige Suchmethode"
 8503,155,Kurse,VC 20,"Der gläserne VC 20 (Teil 6; Schluß)"
@@ -280,7 +280,7 @@
 8508,136,Kurse,Logeleien,"Logeleien (Teil 2)"
 8508,138,Kurse,Effektives Programmieren,"Effektives Programmieren (Teil 7): Sortieren mit dem Computer (Teil 4)"
 8508,144,Kurse,Extern,"C 64 Extern – Der Weg nach draußen (Teil 1)"
-8508,152,Kurse,Grafik,"Hires 3 – Grafikkurs Anwendung (Teil 3; Schluß)"
+8508,152,Kurse,Grafik,"Hires 3 (Teil 3): Grafikkurs Anwendung"
 8509,8,Aktuell,Computer,Amiga – Der neue Supercomputer
 8509,14,Software-Tips,C 128,Erste Fragen und Antworten zum C 128
 8509,17,Hardware-Tests,Musik,Die Musikhardware zum C 64


### PR DESCRIPTION
- With 70daa5f5 you changed the index title for "hires 3" part 3 in 8508, but I think to be consistent we should then apply the same change to the previous parts.
- Did you drop "Schluß" from part 3 on purpose? It's in the original print version and we also already used it in previous issues (eg [Floppykurs part 7 in 8506](https://github.com/mist64/64er-magazin.de/blob/f73e172ce37e03405dfa96a0f813ff747fbc543c/issues/8506/116%20In%20die%20Geheimnisse%20der%20Floppy%20eingetaucht%20(Teil%207).html#L15)).