### PR TITLE
8511 more fixes, formatting, fehlerteufelchen

### DIFF
--- a/issues/8511/149 Streifzüge durch die Grafikwelt (Teil 2).html
+++ b/issues/8511/149 Streifzüge durch die Grafikwelt (Teil 2).html
@@ -21,10 +21,12 @@
         <h1>Streifzüge durch die Grafikwelt (Teil 2)</h1>
         <p class="intro">Grafik mit dem C 64, dem C 128 oder einem anderen Computer. Auf Bildschirm, Drucker oder Plotter. Unser Grafik-System nimmt Formen an.</p>
 
-        <p>Die in dieser und den kommenden Folgen gezeigten Programme sollen möglichst weitgehend unabhängig sein von der Art des verwendeten Grafik-Systems. 0b Sie also einen Commodore 64 mit HiRes-3 oder GBasic (oder&hellip;) benutzen und die Ausgabe auf dem Bildschirm, dem Drucker oder einem Plotter stattfinden lassen, ob Sie zu den Glücklichen gehören, die schon einen Commodore C 128 vor sich stehen haben&hellip; all das soll möglichst weitgehend erfaßt sein. Nicht immer — gestehe ich ganz freimütig —' läßt sich so eine Allgemeingültigkeit erreichen. Besonders in dieser Folge werden die drei größeren Programme noch spezialisiert sein. Die kleineren aber — die fürs Auge — sollen diese Anforderungen schon erfüllen.</p>
+        <p>Die in dieser und den kommenden Folgen gezeigten Programme sollen möglichst weitgehend unabhängig sein von der Art des verwendeten Grafik-Systems. 0b Sie also einen Commodore 64 mit HiRes-3 oder GBasic (oder&hellip;) benutzen und die Ausgabe auf dem Bildschirm, dem Drucker oder einem Plotter stattfinden lassen, ob Sie zu den Glücklichen gehören, die schon einen Commodore C 128 vor sich stehen haben&hellip; all das soll möglichst weitgehend erfaßt sein. Nicht immer — gestehe ich ganz freimütig — läßt sich so eine Allgemeingültigkeit erreichen. Besonders in dieser Folge werden die drei größeren Programme noch spezialisiert sein. Die kleineren aber — die fürs Auge — sollen diese Anforderungen schon erfüllen.</p>
 
-        <p>Dazu werde ich allgemein verständliche Befehlsworte verwenden (wie zum Beispiel LINIE oder PUNKT etc.) und deren Entsprechung in zwei Grafik-Systemen angeben: In HiRes-3-Syntax und in der Syntax, die mit dem Plotter 1520 verwendet wird. Falls Sie ein anderes System benutzen oder einen C 128 Ihr eigen nennen, dürfte es Ihnen nicht schwerfallen, die Syntax-Anpassungen vorzunehmen. Folgende zehn Befehle sollen zunächst vorgestellt werden (wobei sich später noch der eine oder andere zusätzliche Befehl als nötig herausstellen kann): INIT</p>
+        <p>Dazu werde ich allgemein verständliche Befehlsworte verwenden (wie zum Beispiel LINIE oder PUNKT etc.) und deren Entsprechung in zwei Grafik-Systemen angeben: In HiRes-3-Syntax und in der Syntax, die mit dem Plotter 1520 verwendet wird. Falls Sie ein anderes System benutzen oder einen C 128 Ihr eigen nennen, dürfte es Ihnen nicht schwerfallen, die Syntax-Anpassungen vorzunehmen. Folgende zehn Befehle sollen zunächst vorgestellt werden (wobei sich später noch der eine oder andere zusätzliche Befehl als nötig herausstellen kann):</p>
 
+        <h3>INIT</h3>
+        
         <p>Werde ich immer dann verwenden, wenn die Grafik initialisiert werden soll. Damit wird die Grafik eingeschaltet, eine eventuell Bit-Map eingerichtet und gelöscht und die Farbgebung bestimmt.</p>
 
         <h3>START</h3>
@@ -127,12 +129,14 @@
 
         <p>Auch hier wird Ihnen zu Beginn die im Programm gerade enthaltene 3D-Funktion gezeigt und Sie haben die Möglichkeit, statt dessen eine andere einzusetzen. Dann werden Eingaben zum Koordinatensystem verlangt:</p>
 
-        <p>XU = unterer X-Achsenwert<br>
-            X0 = oberer — ” —<br>
-            YU und Y0 = dasselbe für die Y-Achse<br>
-            ZU und Z0 = dasselbe für die Z-Achse.</p>
+        <ul class="plain">
+            <li>XU = unterer X-Achsenwert</li>
+            <li>XO = oberer — " —</li>
+            <li>YU und YO = dasselbe für die Y-Achse</li>
+            <li>ZU und ZO = dasselbe für die Z-Achse.</li>
+        </ul>
 
-        <p>Die maximal und minimal zulässigen Werte für die Z-Achse sind bestimmt durch die Bildschirmdarstellung und die Angaben für die beiden anderen Achsen. Sie werden vor der Z-Werte-Eingabe ausgedruckt. Danach hat man die Möglichkeit, Parameter für die Zeichnung der 3D-Funktion einzugeben. Abgefragt werden die Zeichen- und die Hintergrundfarbe, die Schrittweite in Z-Richtung und der Bereich in X-(aber auch in Z-) Richtung von XA bis XE (und von ZA bis ZE), in dem die Funktion zu zeichnen ist. Wenn das Bild fertig ist, wird oben noch die Funktionsgleichung ausgedruckt. Mit einem Tastendruck gelangt man dann in ein Menü, welches mit »E« die Beendigung des Programmes, mit »G« das Zurückschalten auf den Grafik-Bildschirm (ein Tastendruck führt dann wieder ins Menü), mit »N« den Neubeginn des Programmes und mit »D« den Ausdruck auf dem Drucker 1526 (und kompatible) erlaubt. Ein Beispiel für einen 1526-Ausdruck zeigt Bild 5:</p>
+        <p>Die maximal und minimal zulässigen Werte für die Z-Achse sind bestimmt durch die Bildschirmdarstellung und die Angaben für die beiden anderen Achsen. Sie werden vor der Z-Werte-Eingabe ausgedruckt. Danach hat man die Möglichkeit, Parameter für die Zeichnung der 3D-Funktion einzugeben. Abgefragt werden die Zeichen- und die Hintergrundfarbe, die Schrittweite in Z-Richtung und der Bereich in X- (aber auch in Z-) Richtung von XA bis XE (und von ZA bis ZE), in dem die Funktion zu zeichnen ist. Wenn das Bild fertig ist, wird oben noch die Funktionsgleichung ausgedruckt. Mit einem Tastendruck gelangt man dann in ein Menü, welches mit »E« die Beendigung des Programmes, mit »G« das Zurückschalten auf den Grafik-Bildschirm (ein Tastendruck führt dann wieder ins Menü), mit »N« den Neubeginn des Programmes und mit »D« den Ausdruck auf dem Drucker 1526 (und kompatible) erlaubt. Ein Beispiel für einen 1526-Ausdruck zeigt Bild 5:</p>
 
         <figure>
             <img src="149-5.png" alt="">
@@ -145,7 +149,7 @@
 
         <h3>Literatur:</h3>
 
-        <p>[1] Theo Pavlidis: Algorithms for Graphics and Image Processing, Berlin-Heidelberg 1982: Springer-Verlag, ISBN 3-540-11338-X</p>
+        <p class="source">[1] Theo Pavlidis: Algorithms for Graphics and Image Processing, Berlin-Heidelberg 1982: Springer-Verlag, ISBN 3-540-11338-X</p>
 
         <figure>
             <pre data-filename="spiralen" data-name="Spiralen"></pre>

--- a/issues/8511/157 Dem Klang auf der Spur (Teil 10).html
+++ b/issues/8511/157 Dem Klang auf der Spur (Teil 10).html
@@ -26,14 +26,14 @@
 
         <p>Um zu dem erwähnten Komplettprogramm zu gelangen, benötigt man diesmal mehrere Teile aus verschiedenen Abschnitten des Kurses:</p>
 
-        <p>TODO</p>
-
-        <p>MODULATOR (Teil 4)<br>
-            SOUND EDITOR (Teil 6)<br>
-            SEQUENCER.OBJ (Teil 8)<br>
-            REM TEXT KILLER (Teil 10/Listing 1)<br>
-            SOUND.ED.ZUSATZ (Teil 10/Listing 2)<br>
-            SEQ.ERG.OBJ (Teil 10/Listing 3)</p>
+        <table class="plain right1">
+            <tr><td>MODULATOR</td><td>(Teil 4)</td></tr>
+            <tr><td>SOUND EDITOR</td><td>(Teil 6)</td></tr>
+            <tr><td>SEQUENCER.OBJ</td><td>(Teil 8)</td></tr>
+            <tr><td>REM TEXT KILLER</td><td>(Teil 10/Listing 1)</td></tr>
+            <tr><td>SOUND.ED.ZUSATZ</td><td>(Teil 10/Listing 2)</td></tr>
+            <tr><td>SEQ.ERG.OBJ</td><td>(Teil 10/Listing 3)</td></tr>
+        </table>
 
         <p>Zunächst muß das Programm »Sound-Editor« erweitert werden. Da es den zur Verfügung stehenden Speicher ($0801 — $8FFF) fast vollständig belegt, muß es erst einmal verkürzt werden. Dies ist durch Entfernen der vielen Kommentartexte auch leicht möglich. Wer schon beim Eintippen des Programms die Kommentartexte weggelassen hat, spart sich natürlich jetzt diese Arbeit.</p>
 
@@ -43,10 +43,13 @@
 
         <p>Nun kann Listing 2 (Sound, ed. Erg.) eingegeben werden. Listing 2 enthält sowohl Zeilen, die im alten Sound Editor geändert werden müssen, als auch neu hinzukommende Programmteile, »Sound. Ed. Erg.« ist für sich allein aber kein lauffähiges Programm. Beim Eintippen kann man natürlich die Kommentartexte gleich weglassen. Das entstehende Komplettprogramm sollte man dann sofort auf Disk speichern. Es kann getestet werden, wenn alle Maschinenprogramme und ein Musikdatensatz zur Verfügung stehen.</p>
 
-        <p>An Maschinenprogrammen werden nachgeladen:<br>
-            MODULATOR<br>
-            SEQUENCER.OBJ<br>
-            SEQ.ERG.OBJ</p>
+        <p>An Maschinenprogrammen werden nachgeladen:</p>
+
+        <ul class="plain">
+            <li>MODULATOR</li>
+            <li>SEQUENCER.OBJ</li>
+            <li>SEQ.ERG.OBJ</li>
+        </ul>
 
         <p>Bei dem letzten Programm handelt es sich um eine Ergänzung zum Sequenzer aus Teil 9. Diese Ergänzung, die mit dem MSE eingegeben werden muß (Listing 3), ist für den Betrieb zusammen mit dem Sound-Editor und mit »Modulator« erforderlich. Die technischen Einzelheiten wurden bereits in Teil 9 behandelt und sollen hier nicht mehr besprochen werden.</p>
 
@@ -95,23 +98,26 @@
 
         <p>Sequenzen müssen mit SEQUENZ, (laufende Nummer) eingeleitet werden. Die laufende Nummer muß im Bereich 1 bis 200 liegen.</p>
 
-        <p>Innerhalb einer Sequenz wird mit TRACK, (1, 2 oder 3) angegeben, welcher Stimme die nachfolgenden ; Noten zuzuordnen sind. Man kann in einer Sequenz auch weniger als drei Tracks programmieren. Allen nicht programmierten Tracks ordnet das Generatorprogramm einen 4 Byte langen Dummy-Track zu, der nur aus einer Pause besteht und der nur einmal im Speicher stehen muß.</p>
+        <p>Innerhalb einer Sequenz wird mit TRACK, (1, 2 oder 3) angegeben, welcher Stimme die nachfolgenden Noten zuzuordnen sind. Man kann in einer Sequenz auch weniger als drei Tracks programmieren. Allen nicht programmierten Tracks ordnet das Generatorprogramm einen 4 Byte langen Dummy-Track zu, der nur aus einer Pause besteht und der nur einmal im Speicher stehen muß.</p>
 
-        <p>Innerhalb eines Tracks sind dann folgende Daten zulässig: a — b stellt das Verhältnis zwischen GATE-ON- und GATE-0FF-Zeit ein. Voreinstellung ist 1-1, das heißt, beide Zeiten sind gleich lang. Bei 1-0 hat die GATE-ON-Zeit die maximale Länge, bei 0-1 werden die Noten nur sehr kurz angeschlagen. Die Einstellung hat keinen Einfluß auf die Gesamtlänge der Noten. Diese wird mit a / b eingestellt. Beispiele sind:1/1 ganze Note<br>
-            1/2 halbe Note<br>
-            1/4 Viertelnote<br>
-            1/6 Vierteltriole<br>
-            3/8 punktierte Viertelnote<br>
-            1/8 Achtelnote<br>
-            1/12 Achteltriole</p>
+        <p>Innerhalb eines Tracks sind dann folgende Daten zulässig: a — b stellt das Verhältnis zwischen GATE-ON- und GATE-0FF-Zeit ein. Voreinstellung ist 1-1, das heißt, beide Zeiten sind gleich lang. Bei 1-0 hat die GATE-ON-Zeit die maximale Länge, bei 0-1 werden die Noten nur sehr kurz angeschlagen. Die Einstellung hat <strong>keinen</strong> Einfluß auf die Gesamtlänge der Noten. Diese wird mit a / b eingestellt. Beispiele sind:1/1 ganze Note</p>
+
+        <ul class="plain">
+            <li>1/2 halbe Note</li>
+            <li>1/4 Viertelnote</li>
+            <li>1/6 Vierteltriole</li>
+            <li>3/8 punktierte Viertelnote</li>
+            <li>1/8 Achtelnote</li>
+            <li>1/12 Achteltriole</li>
+        </ul>
 
         <p>Die Längenangabe bezieht sich auf alle Noten bis zur nächsten Längenangabe.</p>
 
-        <p>Als Notennamen werden die üblichen Bezeichnungen C,D,E, F,G,A,H verwendet. Die Notennamen können mit»#«(zum Beispiel F # = Fis) zur Erhöhung um einen Halbton oder mit »B« (zum Beispiel EB = Es) zur Erniedrigung um einen Halbton ergänzt werden. Die Notennamen müssen mit einer Oktavnummer zwischen 0 und 6 versehen sein. Der Kammerton a mit 440 Hz hat in dieser Schreibweise den Namen A3.</p>
+        <p>Als Notennamen werden die üblichen Bezeichnungen C,D,E,F,G,A,H verwendet. Die Notennamen können mit»#« (zum Beispiel F# = Fis) zur Erhöhung um einen Halbton oder mit »B« (zum Beispiel EB = Es) zur Erniedrigung um einen Halbton ergänzt werden. Die Notennamen müssen mit einer Oktavnummer zwischen 0 und 6 versehen sein. Der Kammerton a mit 440 Hz hat in dieser Schreibweise den Namen A3.</p>
 
         <p>P kennzeichnet eine Pause, für die ebenfalls die Längeneinstellung a/b gilt.</p>
 
-        <p>SEQUENZFOLGE, n1, n2, n3..0. Diese Anweisung darf an beliebiger Stelle stehen und muß einmal vorhanden sein. Sie stellt die schon erwähnte Sequenzfolgeliste dar, von der die Abspielreihenfolge der Sequenzen gesteuert wird. Die Sequenzen n1, n2 und so weiter müssen natürlich definiert werden. Die Liste wird mit einer 0 abgeschlossen.</p>
+        <p>SEQUENZFOLGE, n1, n2, n3&hellip;0. Diese Anweisung darf an beliebiger Stelle stehen und muß einmal vorhanden sein. Sie stellt die schon erwähnte Sequenzfolgeliste dar, von der die Abspielreihenfolge der Sequenzen gesteuert wird. Die Sequenzen n1, n2 und so weiter müssen natürlich definiert werden. Die Liste wird mit einer 0 abgeschlossen.</p>
 
         <p>ENDE schließt den Datensatz ab.</p>
 

--- a/issues/8511/162 Adventures, die keine sind.html
+++ b/issues/8511/162 Adventures, die keine sind.html
@@ -21,7 +21,7 @@
         <h1>Adventures, die keine sind</h1>
         <p class="intro">Bei folqenden zwei Spielen fällt die Einordnung schwer: Sind es Adventures, Strategie-Spiele, Action-Spiele oder ganz was anderes, Neues?</p>
 
-        <p>Die zwei Spiele, die wir Ihnen auf dieser Seite vorstellen, haben drei Dinge gemeinsam: Sie haben ein völlig neues Konzept, sind also auf ihre Art einmalig; beide las-.sen sich als Adventures der neuen Schule bezeichnen: beide haben berühmte Vorbilder: ein Buch beziehungsweise eine Popgruppe.</p>
+        <p>Die zwei Spiele, die wir Ihnen auf dieser Seite vorstellen, haben drei Dinge gemeinsam: Sie haben ein völlig neues Konzept, sind also auf ihre Art einmalig; beide lassen sich als Adventures der neuen Schule bezeichnen: beide haben berühmte Vorbilder: ein Buch beziehungsweise eine Popgruppe.</p>
 
         <figure>
             <img src="162-1.png" alt="">
@@ -29,7 +29,7 @@
 
         <p>Bei »The Fourth Protocol« handelt es sich um ein Spiel nach dem gleichnamigen Buch von Frederick Forsyth. Zur Handlung: Durch einen Verräter innerhalb des britischen Geheimdienstes können geheime NATO-Akten in die Sowjetunion gelangen. Über Umwege findet man einen wahrhaft teuflischen Plan einiger Russen heraus. Sie schmuggeln in Einzelteilen eine kleine Atombombe nach England, die sie in der Nähe einer amerikanischen Luftwaffenbasis zünden wollen. Das Ganze soll als Unfall der Amerikaner getarnt werden. Erstrebtes Ziel: Großbritannien soll aus der NATO austreten.</p>
 
-        <p>Der Spieler übernimmt nun in den insgesamt drei Einzelspielen die Rolle des AgentenJohn Preston, der hinter dieses Komplott kommt und es verhindert.</p>
+        <p>Der Spieler übernimmt nun in den insgesamt drei Einzelspielen die Rolle des Agenten John Preston, der hinter dieses Komplott kommt und es verhindert.</p>
 
         <p>Im ersten Spielteil muß der Verräter ausfindig gemacht werden. Die Ermittlungen werden vom Spieler von seinem Büro aus geführt. Von dort aus kann er Akten anfordern, telefonieren, Überwachungen anordnen und vieles andere mehr.</p>
 
@@ -49,11 +49,37 @@
 
         <p>Daß es sich hier im tiefsten Innern um ein Adventure handelt, merkt man kaum. Aber man muß Räume durchsuchen, Gegenstände finden und an bestimmten Stellen einsetzen, alles für Adventures charakteristische Tätigkeiten.</p>
 
-        <p>Die Grafik von »Frankie« ist fantastisch, detailliert, abwechslungsreich und gut animiert. Auch hier gibt es Bildschirmfenster, die sich bei bestimmten Aktionen öffnen und die man sogar betreten kann, um auf andere Spielebenen zu kommen. Die Musikuntermalung von »Frankie« ist ebenfalls gelungen, je nach Spiel ertönen verschiedene Melodien, .die meisten natürlich von der Gruppe »Frankie Goes to Hollywood«. Da sich der Spielverlauf bei »Frankie« jedesmal ändert, wird es wohl kaum langweilig werden.</p>
+        <p>Die Grafik von »Frankie« ist fantastisch, detailliert, abwechslungsreich und gut animiert. Auch hier gibt es Bildschirmfenster, die sich bei bestimmten Aktionen öffnen und die man sogar betreten kann, um auf andere Spielebenen zu kommen. Die Musikuntermalung von »Frankie« ist ebenfalls gelungen, je nach Spiel ertönen verschiedene Melodien, die meisten natürlich von der Gruppe »Frankie Goes to Hollywood«. Da sich der Spielverlauf bei »Frankie« jedesmal ändert, wird es wohl kaum langweilig werden.</p>
 
         <p>Wenn man mal vom dritten Teil des »Fourth Protocol« absieht, liegen hier zwei außergewöhnliche Spiele in hervorragender Qualität vor. Beide überzeugen durch gute Ideen und brillante Ausführung, die kaum Wünsche offen läßt.</p>
 
         <address class="author">(bs)</address>
+
+        <table>
+            <tr><th>Titel</th><th>The Fourth Protocol</th></tr>
+            <tr><th>Spielidee</th><td>11/15</td></tr>
+            <tr><th>Grafik</th><td>10/15</td></tr>
+            <tr><th>Sound</th><td>5/15</td></tr>
+            <tr><th>Schwierigkeit</th><td>12/15</td></tr>
+            <tr><th>Motivation</th><td>12/15</td></tr>
+            <tr><th>Besonderheiten</th><td>Menügesteuertes Adventure</td></tr>
+            <tr><th>Hersteller</th><td>Hutchinson Software</td></tr>
+            <tr><th>Preis</th><td>64,95 Mark (Kassette)</td></tr>
+            <tr><th>Bezugsquelle</th><td>Rushware<br>An der Gümpebrücke 24<br>4044 Kaarst 2</td></tr>
+        </table>
+
+        <table>
+            <tr><th>Titel</th><th>Frankie g. t. H.</th></tr>
+            <tr><th>Spielidee</th><td>13/15</td></tr>
+            <tr><th>Grafik</th><td>11/15</td></tr>
+            <tr><th>Sound</th><td>11/15</td></tr>
+            <tr><th>Schwierigkeit</th><td>10/15</td></tr>
+            <tr><th>Motivation</th><td>13/15</td></tr>
+            <tr><th>Besonderheiten</th><td>viele Spiele im Spiel</td></tr>
+            <tr><th>Hersteller</th><td>Denton Designs / Ocean</td></tr>
+            <tr><th>Preis</th><td>29 Mark (2 Kassetten)</td></tr>
+            <tr><th>Bezugsquelle</th><td>Quelle Versandhaus und Filialen</td></tr>
+        </table>
     </article>
 </body>
 

--- a/issues/8511/165 Handkantenschlag per Joystick.html
+++ b/issues/8511/165 Handkantenschlag per Joystick.html
@@ -53,6 +53,32 @@
         <p>Beide vorgestellten Spiele haben ihren Reiz: Während »Karateka« Strategie und Geschicklichkeit benötigt, kommt es bei »Exploding Fist« auf Geschwindigkeit und Aktion an. Für Solo-Spieler sind beide empfehlenswert, wer auch zu zweit spielen möchte, ist mit »Exploding Fist« besser bedient.</p>
 
         <address class="author">(bs)</address>
+
+        <table>
+            <tr><th>Titel</th><th>Karateka</th></tr>
+            <tr><th>Spielidee</th><td>11/15</td></tr>
+            <tr><th>Grafik</th><td>10/15</td></tr>
+            <tr><th>Sound</th><td>7/15</td></tr>
+            <tr><th>Schwierigkeit</th><td>8/15</td></tr>
+            <tr><th>Motivation</th><td>11/15</td></tr>
+            <tr><th>Besonderheiten</th><td>Zeichentrick-Animation</td></tr>
+            <tr><th>Hersteller</th><td>Broderbund</td></tr>
+            <tr><th>Preis</th><td>79 Mark (Diskette)</td></tr>
+            <tr><th>Bezugsquelle</th><td>Ariolasoft<br>Steinhauser Str. 3<br>8000 München 80</td></tr>
+        </table>
+
+        <table>
+            <tr><th>Titel</th><th>Exploding Fist</th></tr>
+            <tr><th>Spielidee</th><td>10/15</td></tr>
+            <tr><th>Grafik</th><td>11/15</td></tr>
+            <tr><th>Sound</th><td>11/15</td></tr>
+            <tr><th>Schwierigkeit</th><td>12/15</td></tr>
+            <tr><th>Motivation</th><td>12/15</td></tr>
+            <tr><th>Besonderheiten</th><td>viele verschiedene Kampftechniken</td></tr>
+            <tr><th>Hersteller</th><td>Melbourne House</td></tr>
+            <tr><th>Preis</th><td>39 Mark (Kassette)</td></tr>
+            <tr><th>Bezugsquelle</th><td>Rushware<br>An der Gümpebrücke 24<br>4044 Kaarst 2</td></tr>
+        </table>
     </article>
 </body>
 

--- a/issues/8511/171 Noch mehr Bücher.html
+++ b/issues/8511/171 Noch mehr Bücher.html
@@ -15,7 +15,7 @@
     <!-- <meta name="64er.index_category" content="Buchbesprechungen|Anfänger"> -->
     <!-- <meta name="64er.index_title" content="35 ausgesuchte Spiele für Ihren Commodore 64"> -->
     <!-- <meta name="64er.index_category" content="Buchbesprechungen|Spiele"> -->
-    <meta name="64er.id" content="bücher">
+    <meta name="64er.id" content="noch_mehr_bücher">
 </head>
 
 <body>
@@ -26,27 +26,27 @@
 
         <p>Auf der Titelseite heißt es: »Einführung und Referenz für kompetentes Arbeiten«. Und das ist es in der Tat. Das Buch ist eine deutsche Übersetzung und Bearbeitung der englischen Originalausgabe »Programming the Commodore 64« und kann getrost als eines der wenigen Standardwerke zu C 64 gelten.</p>
 
-        <p>Auf über mehr als 600 Seiten findet jeder, der sich etwas intensiver mit dem C 64 beschäftigen will, eine Menge an Informationen, Wissenswertes, Tips und Tricks, Grundlagen und Hinweise für Profis. Betrachtet man alleine die Kapitel über Basic, wird sogar Spezialisten in dieser Hinsicht das Lesen bestimmt nicht langweilig. Man merkt mit jeder Seite, daß dieses Buch von einem wirklichen Könnern mit langer praktischer Erfahrung geschrieben wurde, ohne überflüssige Ballast, konzentriert und doch an wichtigen Stellen ausführlich genug. Das</p>
+        <p>Auf über mehr als 600 Seiten findet jeder, der sich etwas intensiver mit dem C 64 beschäftigen will, eine Menge an Informationen, Wissenswertes, Tips und Tricks, Grundlagen und Hinweise für Profis. Betrachtet man alleine die Kapitel über Basic, wird sogar Spezialisten in dieser Hinsicht das Lesen bestimmt nicht langweilig. Man merkt mit jeder Seite, daß dieses Buch von einem wirklichen Könnern mit langer praktischer Erfahrung geschrieben wurde, ohne überflüssige Ballast, konzentriert und doch an wichtigen Stellen ausführlich genug. Das Buch ist in 17 Kapiteln aufgeteilt, zusätzlich kommt ein Anhang mit wichtigen Tabellen sowie ein ausführliches Stichwortregister. Einen guten Eindruck von dem Umfang der behandelten Themen vermittelt ein Einblick in das Inhaltsverzeichnis:</p>
 
-        <p>Buch ist in 17 Kapiteln aufgeteilt, zusätzlich kommt ein Anhang mit wichtigen Tabellen sowie ein ausführliches Stichwortregister. Einen guten Eindruck von dem Umfang der behandelten Themen vermittelt ein Einblick in das Inhaltsverzeichnis:</p>
+        <p>Kapitel 1 und 2: Dem Vorwort folgt eine allgemeine Einführung über die Eigenschaften des C 64.</p>
 
-        <p>Kapitel 1 und 2: Dem Vorwort folgt eine allgemeine Einführung über die Eigenschaften des C 64.<br>
-            3. C 64/SX 64 Basic zum Nachschlagen. Alle Befehle des C 64 mit vielen interessanten Details.<br>
-            4. Effektives Programmieren in Basic. Optimierung von Basic-Programmen mit vielen Beispielen.<br>
-            5. Architektur des C 64. Einführung in die Hardware des C 64, alles über die Ports.<br>
-            6. C 64 /SX 64 Basic für Professionelle. Wie Besonderheiten des Basic und eine Reihe von Dienstprogrammen und Erweiterungen.<br>
-            7. Einführung in die Maschinensprache des 6510. Umfassende Beschreibung der CPU 6510 mit vielen Beispielen und Problemlösungen.<br>
-            8. Typische Methoden der C 64 Maschinenprogrammierung.<br>
-            Wie man das Kernal, Basic-Routinen und das RAM unter dem ROM nutzt sowie Ändern von Basic-Befehlen etc.<br>
-            9. Verbindung von Basic und Maschinencode.<br>
-            10. Der Befehlssatz der CPU 6510<br>
-            11. ROM-Führer. Speicherbelegung und Betriebssystemroutinen.<br>
-            12. Grafik<br>
-            13. Ton und Musik<br>
-            14. Band<br>
-            15. Diskette<br>
-            16. Die Spiele-Ports. Joysticks, Drehregler, Grafiktablett, Maus und Lichtgriffel etc.<br>
-            17. Drucker, Plotter, Modems</p>
+        <ol start="3" style="margin-block: 0; padding: 0; list-style-position:inside;">
+            <li>C 64/SX 64 Basic zum Nachschlagen. Alle Befehle des C 64 mit vielen interessanten Details.</li>
+            <li>Effektives Programmieren in Basic. Optimierung von Basic-Programmen mit vielen Beispielen.</li>
+            <li>Architektur des C 64. Einführung in die Hardware des C 64, alles über die Ports.</li>
+            <li>C 64 /SX 64 Basic für Professionelle. Wie Besonderheiten des Basic und eine Reihe von Dienstprogrammen und Erweiterungen.</li>
+            <li>Einführung in die Maschinensprache des 6510. Umfassende Beschreibung der CPU 6510 mit vielen Beispielen und Problemlösungen.</li>
+            <li>Typische Methoden der C 64 Maschinenprogrammierung. Wie man das Kernal, Basic-Routinen und das RAM unter dem ROM nutzt sowie Ändern von Basic-Befehlen etc.</li>
+            <li>Verbindung von Basic und Maschinencode.</li>
+            <li>Der Befehlssatz der CPU 6510</li>
+            <li>ROM-Führer. Speicherbelegung und Betriebssystemroutinen.</li>
+            <li>Grafik</li>
+            <li>Ton und Musik</li>
+            <li>Band</li>
+            <li>Diskette</li>
+            <li>Die Spiele-Ports. Joysticks, Drehregler, Grafiktablett, Maus und Lichtgriffel etc.</li>
+            <li>Drucker, Plotter, Modems</li>
+        </ol>
 
         <p>Dieses Buch kann jedem wärmstens empfohlen werden, der sich etwas näher mit dem C 64 beschäftigen will, sei es nur in Basic oder auch in Maschinensprache. Ein Handbuch, das garantiert nicht im Regal verstaubt.</p>
 

--- a/issues/8511/172 An alle Entwickler und Bastler!.html
+++ b/issues/8511/172 An alle Entwickler und Bastler!.html
@@ -22,14 +22,13 @@
             <img src="172-1.png" alt="">
         </figure>
 
-        <p>Haben Sie eine Hardware-Erweiterung für den C 64 selbst gebaut? Es gibt bares Geld zu gewinnen! Wir prämieren die interessanteste und die ideenreichste Erfindung. 0b Sie sich nun morgens computergesteuert einen Eimer Wasser über den Kopf schütten lassen oder ein Interface zur Modellbahnsteuerung gebaut haben, Sie haben eine Chance.</p>
+        <p>Haben Sie eine Hardware-Erweiterung für den C 64 selbst gebaut? Es gibt bares Geld zu gewinnen! Wir prämieren die interessanteste und die ideenreichste Erfindung. Ob Sie sich nun morgens computergesteuert einen Eimer Wasser über den Kopf schütten lassen oder ein Interface zur Modellbahnsteuerung gebaut haben, Sie haben eine Chance.</p>
 
         <p>Die ideenreichste oder kurioseste Bauanleitung wird mit 500 Mark belohnt. Hier kommt es allein auf die Einmaligkeit der Idee an, die natürlich auch schon verwirklicht sein muß.</p>
 
-        <p>Für die interessanteste und beste Bauanleitung steht ein Drucker, ein CP-80X von Melchers &amp; Co bereit.<br>
-            Haben Sie beispielsweise einen Eprommer, einen Analyzer oder ein Interface mit A/D-Wandlung konstruiert und gebaut, senden Sie es uns zu.</p>
+        <p>Für die interessanteste und beste Bauanleitung steht ein Drucker, ein CP-80X von Melchers &amp; Co bereit. Haben Sie beispielsweise einen Eprommer, einen Analyzer oder ein Interface mit A/D-Wandlung konstruiert und gebaut, senden Sie es uns zu.</p>
 
-        <p>Einsendeschluß: 10.12.1985</p>
+        <p class="noindent">Einsendeschluß: 10.12.1985</p>
 
         <p>Natürlich benötigen wir auch einige Unterlagen zu Ihrer Hardware-Entwicklung:</p>
 
@@ -43,13 +42,15 @@
         </ul>
 
 
-        <p>Wenn Sie sich an dem Hardware-Wettbewerb und somit auch an der Gestaltung des 64’er-Magazins mit beteiligen wollen, schreiben Sie einfach bis zum 10.12.1985 an:<br>
-            Markt &amp; Technik<br>
-            Verlag Aktiengesellschaft<br>
-            Redaktion 64'er<br>
-            Herrn Harald Meyer<br>
-            Hans-Pinsel-Str. 2<br>
-            8013 Haar bei München</p>
+        <p>Wenn Sie sich an dem Hardware-Wettbewerb und somit auch an der Gestaltung des 64’er-Magazins mit beteiligen wollen, schreiben Sie einfach bis zum 10.12.1985 an:</p>
+        
+        <address>Markt &amp; Technik
+            Verlag Aktiengesellschaft
+            Redaktion 64'er
+            Herrn Harald Meyer
+            Hans-Pinsel-Str. 2
+            8013 Haar bei München
+        </address>
     </article>
 </body>
 

--- a/issues/8511/172 Ideen-Parade.html
+++ b/issues/8511/172 Ideen-Parade.html
@@ -30,19 +30,20 @@
 
         <p>Für die Teilnehmer mit den fünfzig besten Vorschlägen winken als Preise:</p>
 
-        <p><strong>Platz 1—3: je ein Wochenende im Computercamp bei Fischertechnik im Schwarzwald, mit der Chance, an einer Expertenrunde teilzunehmen.</strong><br>
-            <strong>Der Urheber der besten Idee unter den dreien darf zusätzlich für einen Tag zur Microcomputer 86 (Internationale Microcomputer-Messe vom 29.1.—2.2.I986) nach Frankfurt reisen und erhält dort die Gelegenheit, seine Idee in einer eigenen Pressekonferenz der Fachpresse vorzustellen.</strong><br>
-            <strong>Platz 4—10: je ein Fischer Special-Construction-Kit (Hydraulik und Elektronik) im Wert von 198 Mark.</strong><br>
-            <strong>Platz 11— 50: M &amp; T-Buchgutscheine über je 50 Mark.</strong>
-        </p>
+        <p><strong>Platz 1—3: je ein Wochenende im Computercamp bei Fischertechnik im Schwarzwald, mit der Chance, an einer Expertenrunde teilzunehmen.</strong></p>
+        <p><strong>Der Urheber der besten Idee unter den dreien darf zusätzlich für einen Tag zur Microcomputer 86 (Internationale Microcomputer-Messe vom 29.1.—2.2.1986) nach Frankfurt reisen und erhält dort die Gelegenheit, seine Idee in einer eigenen Pressekonferenz der Fachpresse vorzustellen.</strong></p>
+        <p><strong>Platz 4—10: je ein Fischer Special-Construction-Kit (Hydraulik und Elektronik) im Wert von 198 Mark.</strong></p>
+        <p><strong>Platz 11— 50: M &amp; T-Buchgutscheine über je 50 Mark.</strong></p>
 
-        <p>Senden Sie Ihren Wettbewerbsbeitrag bitte mit Ihrer Adresse versehen an:<br>
-            Markt &amp; Technik<br>
-            Verlag Aktiengesellschaft<br>
-            Redaktion 64'er<br>
-            Kennwort: Steuern und Regeln<br>
-            Hans-Pinsel-Str. 2<br>
-            8013 Haar bei München</p>
+        <p>Senden Sie Ihren Wettbewerbsbeitrag bitte mit Ihrer Adresse versehen an:</p>
+
+        <address>Markt &amp; Technik
+            Verlag Aktiengesellschaft
+            Redaktion 64'er
+            Kennwort: Steuern und Regeln
+            Hans-Pinsel-Str. 2
+            8013 Haar bei München
+        </address>
 
         <p>Die Auswahl der Sieger-Ideen nehmen Experten von Fischertechnik in Zusammenarbeit mit der Redaktion vor.</p>
 

--- a/issues/8511/173 Computer als Steuermann - Ein Thema für Sie_.html
+++ b/issues/8511/173 Computer als Steuermann - Ein Thema für Sie_.html
@@ -17,20 +17,24 @@
 <body>
     <article>
         <h1>Computer als Steuermann - Ein Thema für Sie?</h1>
+
         <p>Mit einem geeigneten Interface und der richtigen Peripherie kann ein Computer mehr als nur rechnen! Dann wird er zum Steuermann, Wächter, Roboter und zu tausend anderen Dingen. Das bedeutet eine neue Dimension. Wie sehr sind Sie, unser Leser, an diesem Thema interessiert? Wie wir uns in Zukunft diesem Thema widmen werden, hängt von Ihrer Anwort ab.</p>
 
         <p>Damit sich die kleine Mühe des Ausfüllens lohnt, verlosen wir unter allen Einsendern 50 Preise, unabhängig von der Ideen-Parade:</p>
 
-        <p><strong>Preis 1—3: Einladung zur Microcomputer 86 (internationale Microcomputer-Messe in Frankfurt vom 29.1.—2.2.1986). An diesem Tag bietet sich Gelegenheit, zum Gespräch mit einer Expertenrunde in Fragen Messen, Steuern und Regeln.</strong><br>
-            <strong>Preis 4—10: je ein Fischer Special-Construction-Kit (Hydraulik und Elektronik) im Wert von 198 Mark.</strong><br>
-            <strong>Preis 11—50: Je ein M &amp; T-Buchgut$chein über 50 Mark.</strong>
-        </p>
+        <p><strong>Preis 1—3: Einladung zur Microcomputer 86 (internationale Microcomputer-Messe in Frankfurt vom 29.1.—2.2.1986). An diesem Tag bietet sich Gelegenheit, zum Gespräch mit einer Expertenrunde in Fragen Messen, Steuern und Regeln.</strong></p>
 
-        <p>Einsendeschluß ist der 15.12.1985. Senden Sie den Fragebogen bitte an:<br>
-            Redaktion 64'er<br>
-            Markt &amp; Technik Verlag AG<br>
-            Hans-Pinsel-Straße 2<br>
-            8013 Haar bei München</p>
+        <p><strong>Preis 4—10: je ein Fischer Special-Construction-Kit (Hydraulik und Elektronik) im Wert von 198 Mark.</strong></p>
+
+        <p><strong>Preis 11—50: Je ein M &amp; T-Buchgut$chein über 50 Mark.</strong></p>
+
+        <p>Einsendeschluß ist der 15.12.1985. Senden Sie den Fragebogen bitte an:</p>
+
+        <address>Redaktion 64'er
+            Markt &amp; Technik Verlag AG
+            Hans-Pinsel-Straße 2
+            8013 Haar bei München
+        </address>    
 
         <p>Der Teil mit dem Namen und der Adresse wird vom Fragebogen getrennt aufbewahrt. Die Auslosung wird durch die Redaktion vorgenommen. Der Rechtsweg ist ausgeschlossen.</p>
 

--- a/issues/8511/176 Einmal im Monat gibt es die Superchance.html
+++ b/issues/8511/176 Einmal im Monat gibt es die Superchance.html
@@ -35,7 +35,9 @@
 
         <p>Aus den besten Listings, die veröffentlicht werden, sucht die 64'er-Redaktion einmal im Monat das »Listing des Monats« aus. Alle Listings, die im 64'er abgedruckt sind, werden mit 100 bis 300 Mark honoriert. Die genaue Vorgehensweise beim Einsenden von Listings ist in dem Beitrag »Wie schicke ich meine Programme ein?« in verschiedenen Ausgaben beschrieben.</p>
 
-        <p>Schicken Sie Ihr Listing an: Redaktion 64'er, Superchance: Listing des Monats, Hans-Pinsel-Str. 2, 8013 Haar bei München.</p>
+        <aside>
+            <p>Schicken Sie Ihr Listing an: Redaktion 64'er, Superchance: Listing des Monats, Hans-Pinsel-Str. 2, 8013 Haar bei München.</p>
+        </aside>
     </article>
 </body>
 

--- a/issues/8511/18 Joysticks.html
+++ b/issues/8511/18 Joysticks.html
@@ -80,6 +80,14 @@
         <p>Wenn Sie sich einen neuen Joystick zulegen wollen, dann sollten Sie Ihr Augenmerk vor allem auf die Lebensdauer richten. Die Lebensdauer eines Joysticks hängt hauptsächlich von zwei Faktoren ab: von der Mechanik des Griffes und von den verwendeten Schaltern. Am besten bewährt haben sich im Test Mikroschalter und Kugelschalter, die beide exakt schalten, und deren Konstruktion keine billige Kunststoffmechanik zuläßt. Natürlich spielt auch der Preis des Joysticks eine Rolle. Man sollte aber berücksichtigen, daß die sehr billigen Joysticks nach viel zu kurzer Zeit nicht mehr zu gebrauchen sind. In diesem Zusammenhang halten wir zwei Joysticks für empfehlenswert: Den Competition Pro und den Tac 2. Beide bieten für einen vertretbaren Preis Leistungen, die sie den teureren Joysticks gleichwertig machen. Wer für seinen Joystick nicht viel Geld ausgeben möchte, dem kommt der Ascom High-Score entgegen. Das gleiche gilt auch für den Quickshot II, der mit Dauerfeuer und weniger Stabilität ausgerüstet ist. Für den umgekehrten Fall, daß der Preis keine wesentliche Rolle spielt, könnte man den Cobra in Erwägung ziehen.</p>
 
         <address class="author">(og)</address>
+
+        <aside class="fehlerteufelchen" id="fehlerteufelchen">
+            <h2>Fehlerteufelchen</h2>
+        
+            <p>Die richtige Bezugsadresse des Joysticks »The Stick« lautet John Hall, und nicht wie angegeben Mükra.</p>
+        
+            <!-- 64'er 12/1985 -->
+        </aside>
     </article>
 </body>
 

--- a/issues/8511/180 Vorschau.html
+++ b/issues/8511/180 Vorschau.html
@@ -43,7 +43,7 @@
 
         <h2>Hilfen für Adventures</h2>
 
-        <p>Kommen Sie mit Adventures nicht klar? Auf fünf Seiten bekommen Sie die Lösungen für bekannte und brandaktuelle Adventures. Sogar die Geheimnisse des 85000-Mark-Adventures »Eureka« werden gelüftet. Lernen Sie den Gewinner kennen. Mehr darüber in der nächsten Ausgabe.</p>
+        <p>Kommen Sie mit Adventures nicht klar? Auf fünf Seiten bekommen Sie die Lösungen für bekannte und brandaktuelle Adventures. Sogar die Geheimnisse des 85&thinsp;000-Mark-Adventures »Eureka« werden gelüftet. Lernen Sie den Gewinner kennen. Mehr darüber in der nächsten Ausgabe.</p>
 
         <figure>
             <img src="180-2.png" alt="">
@@ -61,7 +61,7 @@
 
         <p>Mit unserer Bauanleitung können Sie sich selbst, mit wenig Geld, einen EPROM-Brenner bauen. Er besitzt durchaus die Leistungen, die man von einem professionellen Gerät erwarten kann. Ein Modul-Generator erleichtert Ihnen die Programmierung von EPROMs. Jetzt können Sie auch Basic-Programme schnell von EPROMs laden.</p>
 
-        <h2>Außerdem.</h2>
+        <h2>Außerdem &hellip;</h2>
 
         <ul>
             <li>Hyperscreen. Selbst der Bildschirmrahmen ist nicht vor Sprites sicher</li>

--- a/issues/8511/84 Block Out.html
+++ b/issues/8511/84 Block Out.html
@@ -28,7 +28,7 @@
 
         <table class="plain">
             <tr><td>poke3163,234: poke3218,12</td><td>verhilft zu unendlich vielen Bällen</td></tr>
-            <tr><td>poke 4096,Ballzahl</td><td>verhilft zu endlich vielen Bällen</td></tr>
+            <tr><td><a href="#fehlerteufelchen" class="fehlerteufelchen_link">poke 4096,Ballzahl</a></td><td>verhilft zu endlich vielen Bällen</td></tr>
             <tr><td>poke 3850,12: poke 3853,12</td><td>verhindert, daß das Spiel schneller wird, wenn ein Level abgeräumt ist.</td></tr>
         </table>
 
@@ -39,6 +39,24 @@
             <figcaption>Listing zu Block Out</figcaption>
         </figure>
         <div class="binary_download" data-filename="block out.prg" data-name="Block Out"></div>
+
+        <aside class="fehlerteufelchen" id="fehlerteufelchen">
+            <h2>Fehlerteufelchen</h2>
+        
+            <p>Bei älteren Computern kommt es zu einem Fehler in der Anzeige, da die Bildschirmlösch-Routine das Farb-RAM mit der Hintergrundfarbe statt mit der Zeichenfarbe füllt. Zur Behebung des Fehlers sind folgende Zeilen mit dem MSE einzugeben:</p>
+
+<pre>084E: 20 BB 11 A9 0F 85 D3 20 72
+09BB: 20 BB 11 A9 CF 8D 00 D4 45
+0CC1: 20 BB 11 A9 06 85 D6 A9 74
+11BB: 20 44 E5 A0 FA A9 01 99 BF
+11C3: FF D7 99 F9 D8 99 EB D9 51
+11CB: 99 ED DA 88 D0 Fl 60 00 41
+</pre>
+
+            <p>Anschließend ist das Programm im Direktmodus mit dem Einzeiler SYS (57812)"BLOCK OUTl",8:POKE 193,1:POKE 194,8:POKE 174,211:POKE 175,17:SYS 62957 zu speichern. Ein weiterer Fehler hat sich bei den Trainer-POKEs eingeschlichen. Statt »POKE 4096,Ballzahl« verhilft »POKE 4069« zu entsprechend vielen Bällen.</p>
+
+            <!-- 64'er 2/1986 -->
+        </aside>
     </article>
 </body>
 

--- a/issues/8511/prg/3d-programm.txt
+++ b/issues/8511/prg/3d-programm.txt
@@ -1,6 +1,7 @@
 
 
 ;3d-programm.prg ==0801==
+;inkl. Fehlerteufelchen 4/1986
     1 rem *********************************
     2 rem *                               *
     3 rem *   3d-grafik mittels hires-3   *
@@ -76,10 +77,14 @@
   325 rem
   330 dz=a/2:xt=xu:xh=xo:yt=yu:yh=yo
   335 hfl,f1,f2:trs,xu,xo,yu,yo
+;Zeile 336 neu entspr. Fehlerteufelchen 4/1986
+  336 goto 375
   340 rem
   345 rem ----- koordinatenkreuz ------
   350 rem
   355 tln,xu,0,xo,0:tln,0,yu,0,yo:tln,z2,z2,z1,z1
+;Zeile 356 neu entspr. Fehlerteufelchen 4/1986
+  356 return
   360 rem
   365 rem -----    z-schleife    ------
   370 rem
@@ -87,6 +92,8 @@
   380 trs,xt,xh,yt,yh
   385 funkt,a,xa,xe
   390 nextz
+;Zeile 391 neu entspr. Fehlerteufelchen 4/1986
+  391 zz=fnz (-zu):xt=xu-zz:xh=xo-zz:yt=yu-zz:yh=yo-zz:trs,xt,xh,yt,yh: go­sub 355
   395 tex,"y="+f$,0,3
   400 rem
   405 rem ----- zeichnung fertig ------

--- a/issues/8511/prg/profiprint.txt
+++ b/issues/8511/prg/profiprint.txt
@@ -1,7 +1,10 @@
 
 
 ;profiprint.prg ==0801==
-    1 poke650,128:ifpeek(1022)=0then5000
+;inkl. Fehlerteufelchen 1/1986
+;vor Fehlerteufelchen 1/1986
+;   1 poke650,128:ifpeek(1022)=0then5000
+    1 clr:poke650,128:ifpeek(1022)=0then5000
     2 poke2,32:poke53280,0:poke53281,0:print"{wht}"
    10 ifpeek(1022)=100thenpoke1022,1:load"zeichen b",8,1
    11 ifpeek(1022)=250thenpoke1022,240:load"zeichen din",8,1

--- a/issues/8511/prg/synth.melodien.txt
+++ b/issues/8511/prg/synth.melodien.txt
@@ -1,7 +1,10 @@
 
 
 ;synth.melodien.prg ==0801==
+;inkl. Fehlerteufelchen 12/1985
    10 poke1022,0
+;vor Fehlerteufelchen 12/1985
+;  20 input"parameter";a:poke 1032,a
    20 input"parameter";a:poke1023,a
    30 fort=0to46:readq:poket+832,q:next
    40 sys832


### PR DESCRIPTION
All "Fehlerteufelchen" I found are included, except:
- Reass (12/85 page 109): From what I understand, the current binary is missing this fix. So the correct way would be to fix the binary, use that for the MSE listing and then there's no need for the FT any more, right?
- Listing page 158 (1/86 page 81), because the listing is missing.
- Block out (2/86 page 161). I added it verbatim and didn't fix the binary. I'd say if someone really plans to run it on such an old machine, we can leave it as an exercise for them :grin: 