### PR TITLE
Author metadata cleanup: canonical names + course-part index_titles + sentence-fragment fixes

### DIFF
--- a/issues/8405/104 Alle Tasten-, Zeichen- und Steuercodes.html
+++ b/issues/8405/104 Alle Tasten-, Zeichen- und Steuercodes.html
@@ -11,6 +11,7 @@
 	<meta name="64er.head1" content="Alle Codes">
 	<meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_title" content="Alle Tasten-, Zeichen- und Steuercodes (Teil 2)">
+    <meta name="64er.index_title" content="Alle Tasten-, Zeichen- und Steuercodes (Teil 2)">
     <meta name="64er.toc_category" content="Kurse">
     <meta name="64er.index_category" content="Kurse|Codes">
     <meta name="64er.id" content="codes">

--- a/issues/8406/128 Strubs – ein Precompiler für Basicprogramme (Teil 3).html
+++ b/issues/8406/128 Strubs – ein Precompiler für Basicprogramme (Teil 3).html
@@ -12,6 +12,7 @@
 	<meta name="64er.head2" content="C 64">
     <meta name="64er.toc_category" content="Kurse">
 	<meta name="64er.toc_title" content="Strubs – ein Precompiler für Basic-Programme (Teil 3)">
+	<meta name="64er.index_title" content="Strubs – ein Precompiler für Basic-Programme (Teil 3)">
     <meta name="64er.index_category" content="Kurse|Precompiler">
     <meta name="64er.id" content="strubs">
 </head>

--- a/issues/8407/110 Komfortables Treiberprogramm für Centronics-Drucker.html
+++ b/issues/8407/110 Komfortables Treiberprogramm für Centronics-Drucker.html
@@ -5,7 +5,7 @@
     <title>Komfortables Treiberprogramm für Centronics-Drucker</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="H. Eyssele">
+    <meta name="author" content="Helmut Eyssele">
     <meta name="64er.issue" content="7/84">
     <meta name="64er.pages" content="110-112">
     <meta name="64er.head1" content="Commodore Grafik auf Epson">

--- a/issues/8408/102 Die große Software-Vielfalt der CBMs für den C 64 ausnützen.html
+++ b/issues/8408/102 Die große Software-Vielfalt der CBMs für den C 64 ausnützen.html
@@ -5,7 +5,7 @@
     <title>Die große Software-Vielfalt der CBMs für den C 64 ausnützen</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="M. Heinz, J. Heinz, rg">
+    <meta name="author" content="Martin Heinz, J. Heinz, rg">
     <meta name="64er.issue" content="8/84">
     <meta name="64er.pages" content="102-105">
     <meta name="64er.head1" content="Tips & Tricks">

--- a/issues/8409/162 Datenbrennerei.html
+++ b/issues/8409/162 Datenbrennerei.html
@@ -5,7 +5,7 @@
     <title>Datenbrennerei</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Arnd Wängler, M. Frank, gk">
+    <meta name="author" content="Arnd Wängler, Michael Frank, gk">
     <meta name="64er.issue" content="9/84">
     <meta name="64er.pages" content="162-163">
     <meta name="64er.head1" content="Software">

--- a/issues/8409/89 Der Super-Sprite-Editor.html
+++ b/issues/8409/89 Der Super-Sprite-Editor.html
@@ -5,7 +5,7 @@
     <title>Der Super-Sprite-Editor</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="A. Kölbach, rg">
+    <meta name="author" content="Andreas Kölbach, rg">
     <meta name="64er.issue" content="9/84">
     <meta name="64er.pages" content="89-93">
     <meta name="64er.head1" content="Grafik">

--- a/issues/8410/146 Reise durch die Wunderwelt der Grafik - Teil 7.html
+++ b/issues/8410/146 Reise durch die Wunderwelt der Grafik - Teil 7.html
@@ -12,6 +12,7 @@
     <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Kurse">
     <meta name="64er.toc_title" content="Reise durch die Wunderwelt der Grafik (Teil 7)">
+    <meta name="64er.index_title" content="Reise durch die Wunderwelt der Grafik (Teil 7)">
     <meta name="64er.index_category" content="Kurse|Grafik">
     <meta name="64er.id" content="grafik">
 </head>

--- a/issues/8410/150 Assembler ist keine Alchimie – 2. Teil.html
+++ b/issues/8410/150 Assembler ist keine Alchimie – 2. Teil.html
@@ -12,6 +12,7 @@
     <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Kurse">
     <meta name="64er.toc_title" content="Assembler ist keine Alchimie (Teil 2)">
+    <meta name="64er.index_title" content="Assembler ist keine Alchimie (Teil 2)">
     <meta name="64er.index_category" content="Kurse|Assembler">
     <meta name="64er.id" content="assembler">
 </head>

--- a/issues/8411/121 Assembler ist keine Alchimie – Teil 3.html
+++ b/issues/8411/121 Assembler ist keine Alchimie – Teil 3.html
@@ -12,6 +12,7 @@
     <meta name="64er.head2" content="C 64/VC 20">
     <meta name="64er.toc_category" content="Kurse">
     <meta name="64er.toc_title" content="Assembler ist keine Alchimie (Teil 3)">
+    <meta name="64er.index_title" content="Assembler ist keine Alchimie (Teil 3)">
     <meta name="64er.index_category" content="Kurse|Assembler">
     <meta name="64er.id" content="assembler">
 </head>

--- a/issues/8411/126 Der gläserne VC 20 – Teil 3.html
+++ b/issues/8411/126 Der gläserne VC 20 – Teil 3.html
@@ -12,6 +12,7 @@
     <meta name="64er.head2" content="VC 20">
     <meta name="64er.toc_category" content="Kurse">
     <meta name="64er.toc_title" content="Der gläserne VC 20 (Teil 3)">
+    <meta name="64er.index_title" content="Der gläserne VC 20 (Teil 3)">
     <meta name="64er.index_category" content="Kurse|VC 20">
     <meta name="64er.id" content="vc20">
 </head>

--- a/issues/8501/72 Checksummer — keine Fehler mehr beim Abtippen von Listings.html
+++ b/issues/8501/72 Checksummer — keine Fehler mehr beim Abtippen von Listings.html
@@ -5,7 +5,7 @@
     <title>Checksummer — keine Fehler mehr beim Abtippen von Listings</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="F. Lonczewski, gk">
+    <meta name="author" content="Frank Lonczewski, gk">
     <meta name="64er.issue" content="1/85">
     <meta name="64er.pages" content="72-74">
     <meta name="64er.head1" content="Anwendung">

--- a/issues/8502/65 Checksummer — keine Fehler mehr beim Abtippen von Listings.html
+++ b/issues/8502/65 Checksummer — keine Fehler mehr beim Abtippen von Listings.html
@@ -5,7 +5,7 @@
     <title>Checksummer — keine Fehler mehr beim Abtippen von Listings</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="F. Lonczewski, gk">
+    <meta name="author" content="Frank Lonczewski, gk">
     <meta name="64er.issue" content="2/85">
     <meta name="64er.pages" content="65-67">
     <meta name="64er.head1" content="Anwendung">

--- a/issues/8505/164 Funktionen für Anfänger.html
+++ b/issues/8505/164 Funktionen für Anfänger.html
@@ -5,7 +5,7 @@
     <title>Funktionen für Anfänger</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Prof.Dr. Leuschner, gk">
+    <meta name="author" content="Prof. Burkhard Leuschner, gk">
     <meta name="64er.issue" content="5/85">
     <meta name="64er.pages" content="164,167-169">
     <meta name="64er.head1" content="Funktionen">

--- a/issues/8507/75 REM-Killer.html
+++ b/issues/8507/75 REM-Killer.html
@@ -5,7 +5,7 @@
     <title>REM-Killer</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Dipl. Ing. Wilhelm Meierhofer, hm">
+    <meta name="author" content="Dipl.-Ing. Wilhelm Meierhofer, hm">
     <meta name="64er.issue" content="7/85">
     <meta name="64er.pages" content="75-76">
     <meta name="64er.head1" content="Tips und Tricks">

--- a/issues/8509/140 C — Die professionelle Programmiersprache für den C 64.html
+++ b/issues/8509/140 C — Die professionelle Programmiersprache für den C 64.html
@@ -5,7 +5,7 @@
     <title>C — Die professionelle Programmiersprache für den C 64</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="M. Thomas, ev">
+    <meta name="author" content="Michael Thomas, ev">
     <meta name="64er.issue" content="9/85">
     <meta name="64er.pages" content="140-143">
     <meta name="64er.head1" content="Software-Test">

--- a/issues/8511/112 Bücher.html
+++ b/issues/8511/112 Bücher.html
@@ -5,7 +5,7 @@
     <title>Bücher</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Doris Eichmeier, D. Hein, Gerhard Pehland, Heimo Ponnath">
+    <meta name="author" content="Doris Eichmeier, Dieter Hein, Gerhard Pehland, Heimo Ponnath">
     <meta name="64er.issue" content="11/85">
     <meta name="64er.pages" content="112">
     <meta name="64er.head1" content="Bücher">

--- a/issues/8511/38 Epson JX-80 — Das vielfarbige Druck-Genie.html
+++ b/issues/8511/38 Epson JX-80 — Das vielfarbige Druck-Genie.html
@@ -5,7 +5,7 @@
     <title>Epson JX-80 — Das vielfarbige Druck-Genie</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="E. Konther, M. Börner, aw">
+    <meta name="author" content="Elisabeth Konther, Michael Börner, aw">
     <meta name="64er.issue" content="11/85">
     <meta name="64er.pages" content="38-39">
     <meta name="64er.head1" content="Hardware-Test">

--- a/issues/8511/40 MPS 803 – Ein Drucker für alle Gelegenheiten_.html
+++ b/issues/8511/40 MPS 803 – Ein Drucker für alle Gelegenheiten_.html
@@ -5,7 +5,7 @@
     <title>MPS 803 – Ein Drucker für alle Gelegenheiten?</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="E. Konther, aw">
+    <meta name="author" content="Elisabeth Konther, aw">
     <meta name="64er.issue" content="11/85">
     <meta name="64er.head1" content="Hardware-Test">
     <meta name="64er.head2" content="C 64">

--- a/issues/8511/41 SP 1000 VC — Superstar mit Haken.html
+++ b/issues/8511/41 SP 1000 VC — Superstar mit Haken.html
@@ -5,7 +5,7 @@
     <title>SP 1000 VC — Superstar mit Haken</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="E. Konther, aw">
+    <meta name="author" content="Elisabeth Konther, aw">
     <meta name="64er.issue" content="11/85">
     <meta name="64er.pages" content="41-42">
     <meta name="64er.head1" content="Hardware-Test">

--- a/issues/8511/96 Ergänzungen zu Hypra-Ass.html
+++ b/issues/8511/96 Ergänzungen zu Hypra-Ass.html
@@ -5,7 +5,7 @@
     <title>Ergänzungen zu Hypra-Ass</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Gert Möllmann, ah">
+    <meta name="author" content="Gerd Möllmann, ah">
     <meta name="64er.issue" content="11/85">
     <meta name="64er.pages" content="96">
     <meta name="64er.head1" content="Tips und Tricks">

--- a/issues/8602/145 Memory Map mit Wandervorschlägen.html
+++ b/issues/8602/145 Memory Map mit Wandervorschlägen.html
@@ -5,7 +5,7 @@
     <title>Memory Map mit Wandervorschlägen — Teil 15</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Dr.H. Hauck, ah">
+    <meta name="author" content="Dr. Helmuth Hauck, ah">
     <meta name="64er.issue" content="2/86">
     <meta name="64er.pages" content="145-148">
     <meta name="64er.head1" content="Kurs: Speicherlandschaft">

--- a/issues/8602/156 Programmieren Sie strukturiert! (Teil 2).html
+++ b/issues/8602/156 Programmieren Sie strukturiert! (Teil 2).html
@@ -5,7 +5,7 @@
     <title>Programmieren Sie strukturiert! (Teil 2)</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Burkhard Leuschner, gk">
+    <meta name="author" content="Prof. Burkhard Leuschner, gk">
     <meta name="64er.issue" content="2/86">
     <meta name="64er.pages" content="156,158,160">
     <meta name="64er.head1" content="Kurs: Strukturiertes Programmieren">

--- a/issues/8602/33 Citizen — der Riesenzwerg.html
+++ b/issues/8602/33 Citizen — der Riesenzwerg.html
@@ -5,7 +5,7 @@
     <title>Citizen — der Riesenzwerg</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="E. Konther, aw">
+    <meta name="author" content="Elisabeth Konther, aw">
     <meta name="64er.issue" content="2/86">
     <meta name="64er.pages" content="33,167">
     <meta name="64er.head1" content="Drucker">

--- a/issues/8602/52 Weg mit dem Müll.html
+++ b/issues/8602/52 Weg mit dem Müll.html
@@ -5,7 +5,7 @@
     <title>Weg mit dem Müll</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="W. Meierhofer, og">
+    <meta name="author" content="Dipl.-Ing. Wilhelm Meierhofer, og">
     <meta name="64er.issue" content="2/86">
     <meta name="64er.pages" content="52-56">
     <meta name="64er.head1" content="Listing des Monats">

--- a/issues/8603/122 Memory Map mit Wandervorschlägen (Teil 16).html
+++ b/issues/8603/122 Memory Map mit Wandervorschlägen (Teil 16).html
@@ -5,7 +5,7 @@
     <title>Memory Map mit Wandervorschlägen (Teil 16)</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Dr.H. Hauck, ah">
+    <meta name="author" content="Dr. Helmuth Hauck, ah">
     <meta name="64er.issue" content="3/86">
     <meta name="64er.pages" content="122-126">
     <meta name="64er.head1" content="Kurs: Speicherlandschaft">

--- a/issues/8603/14 Hackerkongress in Hamburg.html
+++ b/issues/8603/14 Hackerkongress in Hamburg.html
@@ -5,7 +5,7 @@
     <title>DFÜ-News: Hackerkongress in Hamburg</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="BHP, Heimo Ponnath, hm">
+    <meta name="author" content="B.H.P., Heimo Ponnath, hm">
     <meta name="64er.issue" content="3/86">
     <meta name="64er.pages" content="14">
     <meta name="64er.head1" content="Aktuell">

--- a/issues/8603/31 Der Präsident 6313 C — das preiswerte Schwergewicht.html
+++ b/issues/8603/31 Der Präsident 6313 C — das preiswerte Schwergewicht.html
@@ -5,7 +5,7 @@
     <title>Der Präsident 6313 C — das preiswerte Schwergewicht</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="E. Konther, aw">
+    <meta name="author" content="Elisabeth Konther, aw">
     <meta name="64er.issue" content="3/86">
     <meta name="64er.pages" content="31-32">
     <meta name="64er.head1" content="Hardware-Test">

--- a/issues/8604/12 DFÜ-News.html
+++ b/issues/8604/12 DFÜ-News.html
@@ -5,7 +5,7 @@
     <title>DFÜ-News</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="BHP, hm">
+    <meta name="author" content="B.H.P., hm">
     <meta name="64er.issue" content="4/86">
     <meta name="64er.head1" content="Aktuelles">
     <meta name="64er.pages" content="12-13">

--- a/issues/8606/134 Von Basic zu Assembler (Teil 4).html
+++ b/issues/8606/134 Von Basic zu Assembler (Teil 4).html
@@ -5,7 +5,7 @@
     <title>Von Basic zu Assembler (Teil 4)</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="H. Ponnath, dm">
+    <meta name="author" content="Heimo Ponnath, dm">
     <meta name="64er.issue" content="6/86">
     <meta name="64er.pages" content="134-138">
     <meta name="64er.head2" content="C 64/C 128">

--- a/issues/8606/145 Memory Map mit Wandervorschlägen Teil 18 (Schluß).html
+++ b/issues/8606/145 Memory Map mit Wandervorschlägen Teil 18 (Schluß).html
@@ -5,7 +5,7 @@
     <title>Memory Map mit Wandervorschlägen Teil 18 (Schluß)</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Dr. H. Hauck, ah">
+    <meta name="author" content="Dr. Helmuth Hauck, ah">
     <meta name="64er.issue" content="6/86">
     <meta name="64er.pages" content="145-146,148-149">
     <meta name="64er.head1" content="Speicherlandschaft">

--- a/issues/8606/44 Datei ohne Grenzen_.html
+++ b/issues/8606/44 Datei ohne Grenzen_.html
@@ -5,7 +5,7 @@
     <title>Datei ohne Grenzen?</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="S. Baloui, tr">
+    <meta name="author" content="Said Baloui, tr">
     <meta name="64er.issue" content="6/86">
     <meta name="64er.pages" content="44-46">
     <meta name="64er.head1" content="Daten verwalten">

--- a/issues/8606/92 64'er Extra.html
+++ b/issues/8606/92 64'er Extra.html
@@ -5,7 +5,7 @@
     <title>64'er Extra: Speicherzellen 0 bis 1023 nach Funktionen geordnet</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Dr. H. Hauck, ah">
+    <meta name="author" content="Dr. Helmuth Hauck, ah">
     <meta name="64er.issue" content="6/86">
     <meta name="64er.pages" content="92-93">
     <meta name="64er.head2" content="C 64/VC 20">

--- a/issues/8606/97 Bücher.html
+++ b/issues/8606/97 Bücher.html
@@ -5,7 +5,7 @@
     <title>Bücher</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="D. Hein, ev, ev">
+    <meta name="author" content="Dieter Hein, ev, ev">
     <meta name="64er.issue" content="6/86">
     <meta name="64er.pages" content="97">
     <meta name="64er.head2" content="C 64/C 128/Amiga">

--- a/issues/SH8501/4 Checksummer — keine Fehler mehr beim Abtippen von Listings.html
+++ b/issues/SH8501/4 Checksummer — keine Fehler mehr beim Abtippen von Listings.html
@@ -5,7 +5,7 @@
     <title>Checksummer — keine Fehler mehr beim Abtippen von Listings</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="F. Lonczewski, gk">
+    <meta name="author" content="Frank Lonczewski, gk">
     <meta name="64er.issue" content="Sonderheft 1/85">
     <meta name="64er.pages" content="4-7">
     <meta name="64er.head1" content="Checksummer">

--- a/issues/SH8502/63 Neuer Checksummer 64 — blitzschnell und kürzer.html
+++ b/issues/SH8502/63 Neuer Checksummer 64 — blitzschnell und kürzer.html
@@ -5,7 +5,7 @@
     <title>Neuer Checksummer 64 — blitzschnell und kürzer</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="F. Lonczewski, gk">
+    <meta name="author" content="Frank Lonczewski, gk">
     <meta name="64er.issue" content="Sonderheft 2/85">
     <meta name="64er.pages" content="63-64">
     <meta name="64er.head1" content="Checksummer">

--- a/issues/SH8503/6 Checksummer 64 — Neu.html
+++ b/issues/SH8503/6 Checksummer 64 — Neu.html
@@ -5,7 +5,7 @@
     <title>Checksummer 64 — Neu</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="F. Lonczewski, gk">
+    <meta name="author" content="Frank Lonczewski, gk">
     <meta name="64er.issue" content="Sonderheft 3/85">
     <meta name="64er.pages" content="6-7">
     <meta name="64er.head1" content="Eintipphilfe">

--- a/issues/SH8504/126 3D-Darstellung in 19 Zeilen.html
+++ b/issues/SH8504/126 3D-Darstellung in 19 Zeilen.html
@@ -5,7 +5,7 @@
     <title>3D-Darstellung in 19 Zeilen</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Achim Vowe, ev, Der Absolutbetrag und die IF-Anweisungen sind nötig, um die durch Quotientenbildung verlorengegangene Vorzeicheninformation wiederzugewinnen.">
+    <meta name="author" content="Achim Vowe, ev">
     <meta name="64er.issue" content="Sonderheft 4/85">
     <meta name="64er.pages" content="126-127">
     <meta name="64er.toc_category" content="Tips und Tricks">
@@ -94,7 +94,7 @@
             B = W+A; d’ = COS(B)*e; h’ = SIN(B)*e<br>
             ap’ = ar+d’; op’=or+h’</p>
 
-        <address class="author">(Der Absolutbetrag und die IF-Anweisungen sind nötig, um die durch Quotientenbildung verlorengegangene Vorzeicheninformation wiederzugewinnen.)</address>
+        <p>Der Absolutbetrag und die IF-Anweisungen sind nötig, um die durch Quotientenbildung verlorengegangene Vorzeicheninformation wiederzugewinnen.</p>
 
         <p>Diese mathematischen Ausführungen waren nur für den an den Grundlagen Interessierten gedacht. Natürlich kann man auch mathematisch unbelastet mit dem Programm experimentieren.</p>
 

--- a/issues/SH8504/22 Die billigste Centronics-Schnittstelle für den C 64.html
+++ b/issues/SH8504/22 Die billigste Centronics-Schnittstelle für den C 64.html
@@ -5,7 +5,7 @@
   <title>Die billigste Centronics-Schnittstelle für den C 64</title>
   <meta charset="UTF-8">
   <link rel="stylesheet" href="../style.css">
-  <meta name="author" content="H. Eyssele, hm">
+  <meta name="author" content="Helmut Eyssele, hm">
   <meta name="64er.issue" content="Sonderheft 4/85">
   <meta name="64er.pages" content="22-14">
   <meta name="64er.toc_category" content="Drucker-Anwendung">

--- a/issues/SH8504/6 Checksummer 64 — Neu.html
+++ b/issues/SH8504/6 Checksummer 64 — Neu.html
@@ -5,7 +5,7 @@
     <title>Checksummer 64 — Neu</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="F. Lonczewski, gk">
+    <meta name="author" content="Frank Lonczewski, gk">
     <meta name="64er.issue" content="Sonderheft 4/85">
     <meta name="64er.pages" content="6-7">
     <meta name="64er.toc_category" content="Prüfsummenlistings">

--- a/issues/SH8504/62 Hardcopy MPS802_1526.html
+++ b/issues/SH8504/62 Hardcopy MPS802_1526.html
@@ -5,7 +5,7 @@
     <title>Hardcopy MPS 802/1526</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Ralph Hoffmann, Christoph Bertog, rg, in normaler und reverser Darstellung">
+    <meta name="author" content="Ralph Hoffmann, Christoph Bertog, rg">
     <meta name="64er.issue" content="Sonderheft 4/85">
     <meta name="64er.pages" content="62">
     <meta name="64er.toc_category" content="Hardcopy-Routinen">
@@ -30,7 +30,7 @@
 
         <p>CHR$(160),(161),(162),(172),(187),(188),(190),(191)</p>
 
-        <address class="author">(in normaler und reverser Darstellung)</address>
+        <p>in normaler und reverser Darstellung</p>
 
         <p>Während des Druckes ist auf den HiRes-Bildschirm umgeschaltet, so daß man die Abarbeitung verfolgen kann. Nach Fertigstellung des ersten Teiles unterbricht das Programm, um ein Neujustieren des Druckerpapiers zu ermöglichen. Danach wird der zweite Teil ausgedruckt. Die Bilder sollten sich im Speicher ab Adresse 8192 = $2000 befinden.</p>
 

--- a/issues/SH8504/8 MSE – Abtippen sicher und leicht gemacht.html
+++ b/issues/SH8504/8 MSE – Abtippen sicher und leicht gemacht.html
@@ -5,7 +5,7 @@
     <title>MSE – Abtippen sicher und leicht gemacht</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="N. Mann, D. Weineck, gk">
+    <meta name="author" content="Norfried Mann, Dietrich Weineck, gk">
     <meta name="64er.issue" content="Sonderheft 4/85">
     <meta name="64er.pages" content="8-9">
     <meta name="64er.toc_category" content="Prüfsummenlistings">

--- a/issues/SH8505/103 ON ERROR GOTO.html
+++ b/issues/SH8505/103 ON ERROR GOTO.html
@@ -5,7 +5,7 @@
     <title>ON ERROR GOTO</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Kunz, tr">
+    <meta name="author" content="Herbert Kunz, tr">
     <meta name="64er.issue" content="Sonderheft 5/85">
     <meta name="64er.pages" content="103">
     <meta name="64er.head1" content="Basic-Erweiterungen">

--- a/issues/SH8505/6 Checksummer 64 — Neu.html
+++ b/issues/SH8505/6 Checksummer 64 — Neu.html
@@ -5,7 +5,7 @@
     <title>Checksummer 64 — Neu</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="F. Lonczewski, gk">
+    <meta name="author" content="Frank Lonczewski, gk">
     <meta name="64er.issue" content="Sonderheft 5/85">
     <meta name="64er.pages" content="6-7">
     <meta name="64er.head1" content="Eintipphilfe">

--- a/issues/SH8505/74 Disk-Füller.html
+++ b/issues/SH8505/74 Disk-Füller.html
@@ -5,7 +5,7 @@
     <title>Disk-Füller</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="U. Gerlach, bs">
+    <meta name="author" content="Uwe Gerlach, bs">
     <meta name="64er.issue" content="Sonderheft 5/85">
     <meta name="64er.pages" content="74-75">
     <meta name="64er.head1" content="Floppy">

--- a/issues/SH8505/8 MSE - Abtippen sicher und leicht gemacht.html
+++ b/issues/SH8505/8 MSE - Abtippen sicher und leicht gemacht.html
@@ -5,7 +5,7 @@
     <title>MSE - Abtippen sicher und leicht gemacht</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="N. Mann ,  D. Weineck ,  gk">
+    <meta name="author" content="Norfried Mann, Dietrich Weineck, gk">
     <meta name="64er.issue" content="Sonderheft 5/85">
     <meta name="64er.pages" content="8-9">
     <meta name="64er.head1" content="Eintipphilfe">

--- a/issues/SH8506/116 Tiny-Forth-Compiler zum Abtippen.html
+++ b/issues/SH8506/116 Tiny-Forth-Compiler zum Abtippen.html
@@ -5,7 +5,7 @@
     <title>Tiny-Forth-Compiler zum Abtippen</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Alexander Schindowski, ev">
+    <meta name="author" content="Alexander C. Schindowski, ev">
     <meta name="64er.issue" content="Sonderheft 6/85">
     <meta name="64er.pages" content="116-118,120-124">
     <meta name="64er.toc_category" content="Hilfsprogramm">

--- a/issues/SH8506/16 Checksummer 64 — Neu.html
+++ b/issues/SH8506/16 Checksummer 64 — Neu.html
@@ -5,7 +5,7 @@
     <title>Checksummer 64 — Neu</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="F. Lonczewski, gk">
+    <meta name="author" content="Frank Lonczewski, gk">
     <meta name="64er.issue" content="Sonderheft 6/85">
     <meta name="64er.pages" content="16-17">
     <meta name="64er.toc_category" content="Eintipphilfen">

--- a/issues/SH8506/18 MSE-Abtippen sicher und leicht gemacht.html
+++ b/issues/SH8506/18 MSE-Abtippen sicher und leicht gemacht.html
@@ -5,7 +5,7 @@
     <title>MSE - Abtippen sicher und leicht gemacht</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="N. Mann ,  D. Weineck ,  gk">
+    <meta name="author" content="Norfried Mann, Dietrich Weineck, gk">
     <meta name="64er.issue" content="Sonderheft 6/85">
     <meta name="64er.pages" content="18-19">
     <meta name="64er.toc_category" content="Eintipphilfen">

--- a/issues/SH8506/7 Vier Pseudo-VICs mit 32 Sprites.html
+++ b/issues/SH8506/7 Vier Pseudo-VICs mit 32 Sprites.html
@@ -5,7 +5,7 @@
     <title>Vier Pseudo-VICs mit 32 Sprites</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Jürgen und Stefan Haas, bs">
+    <meta name="author" content="Jürgen Haas, Stefan Haas, bs">
     <meta name="64er.issue" content="Sonderheft 6/85">
     <meta name="64er.pages" content="7,67-70">
     <meta name="64er.toc_category" content="Grafik">

--- a/issues/SH8506/7 »Happysynth«, der Traum eines jeden Musikers.html
+++ b/issues/SH8506/7 »Happysynth«, der Traum eines jeden Musikers.html
@@ -5,7 +5,7 @@
     <title>»Happysynth«, der Traum eines jeden Musikers</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Bernhard Carli, Christian Spitzner, tr">
+    <meta name="author" content="Bernhard Carli, Christian Quirin Spitzner, tr">
     <meta name="64er.issue" content="Sonderheft 6/85">
     <meta name="64er.pages" content="7,48-56">
     <meta name="64er.toc_category" content="Anwendung">

--- a/issues/SH8507/86 Datei total.html
+++ b/issues/SH8507/86 Datei total.html
@@ -5,7 +5,7 @@
     <title>Datei total</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Hinweis: Um zu verhindern, daß der Aufbau der Menüs zerstört wird, ist die Zeichensatzänderung nur im Bereich der Dateimaske und des Helpscreens 2 wirksam., Martin Hecht, tr">
+    <meta name="author" content="Martin Hecht, tr">
     <meta name="64er.issue" content="Sonderheft 7/85">
     <meta name="64er.pages" content="86-95">
     <meta name="64er.head1" content="Anwendung">
@@ -300,7 +300,7 @@
         </ul>
 
 
-        <address class="author">(Hinweis: Um zu verhindern, daß der Aufbau der Menüs zerstört wird, ist die Zeichensatzänderung nur im Bereich der Dateimaske und des Helpscreens 2 wirksam.)</address>
+        <p>Hinweis: Um zu verhindern, daß der Aufbau der Menüs zerstört wird, ist die Zeichensatzänderung nur im Bereich der Dateimaske und des Helpscreens 2 wirksam.</p>
 
         <p>Mit »SHIFT« + »RETURN« können Sie jederzeit in das Hauptmenü zurückkehren.</p>
 

--- a/issues/SH8508/164 Superhirn, einmal andersherum.html
+++ b/issues/SH8508/164 Superhirn, einmal andersherum.html
@@ -5,7 +5,7 @@
     <title>Superhirn, einmal andersherum</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="A. Reiser, H. Bauschke, og">
+    <meta name="author" content="A. Reiser, Heinz Bauschke, og">
     <meta name="64er.issue" content="Sonderheft 8/85">
     <meta name="64er.pages" content="164-166">
     <meta name="64er.head1" content="Tips und Tricks">

--- a/issues/SH8508/178 ROM-Routinen in eigenen Programmen.html
+++ b/issues/SH8508/178 ROM-Routinen in eigenen Programmen.html
@@ -5,7 +5,7 @@
     <title>ROM-Routinen in eigenen Programmen</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="Heino Ponnath, hm">
+    <meta name="author" content="Heimo Ponnath, hm">
     <meta name="64er.issue" content="Sonderheft 8/85">
     <meta name="64er.pages" content="178-180">
     <meta name="64er.head1" content="Tabellen">

--- a/issues/SH8508/184 Befehlsübersicht - Zusammenfassung.html
+++ b/issues/SH8508/184 Befehlsübersicht - Zusammenfassung.html
@@ -5,7 +5,7 @@
     <title>Befehlsübersicht - Zusammenfassung</title>
     <meta charset="UTF-8">
     <link rel="stylesheet" href="../style.css">
-    <meta name="author" content="ak">
+    <meta name="author" content="ah">
     <meta name="64er.issue" content="Sonderheft 8/85">
     <meta name="64er.pages" content="184-185">
     <meta name="64er.head1" content="Tabellen">


### PR DESCRIPTION
## Summary
Cross-issue consolidation of `<meta name="author">` values so each person resolves to a single canonical name. Plus a few small data-quality fixes uncovered by the consolidation. Prep work for the upcoming by-author pages feature (PR #269 port).

**Author meta consolidation (45 files, ~48 token edits):**
- Initial-only → full given-name: e.g. D. Hein → Dieter Hein; H. Eyssele → Helmut Eyssele; F. Lonczewski → Frank Lonczewski (×7); E. Konther → Elisabeth Konther (×5); N. Mann → Norfried Mann; D. Weineck → Dietrich Weineck; A. Kölbach → Andreas Kölbach; M. Thomas → Michael Thomas; S. Baloui → Said Baloui; M. Börner / M. Frank / U. Gerlach / M. Heinz / H. Bauschke / Alexander Schindowski → Alexander C. Schindowski; Christian Spitzner → Christian Quirin Spitzner.
- Academic titles preserved on the canonical form: Dr. Helmuth Hauck, Dipl.-Ing. Wilhelm Meierhofer, Prof. Burkhard Leuschner — every reference now uses the title-prefixed canonical.
- OCR/spelling: Gert → Gerd Möllmann; Heino / H. Ponnath → Heimo Ponnath.
- Pseudonym variant: BHP → B.H.P. (2 files).
- Single-token fix: Kunz → Herbert Kunz (SH8505/103, cross-confirmed within same Sonderheft).
- Multi-person byline split: "Jürgen und Stefan Haas" → "Jürgen Haas, Stefan Haas".
- Editor code: SH8508/184 meta `"ak"` → `"ah"` (Achim Hübner; topic of Hypra-Ass/Reass/SMON command tables matches his portfolio).

**Course-part `index_title`s (6 files):** added missing `<meta 64er.index_title>` to 6 course articles that had only `toc_title` with "(Teil N)". Keeps the course-series consistency check passing.

**Sentence-fragment cleanup (3 files):** articles whose `<meta name="author">` had prose stuffed in (a sentence accidentally absorbed during an old import) cleaned to the real authors from the byline. The spurious `<address class="author">(prose)</address>` blocks converted to plain `<p>` paragraphs.
- SH8507/86 Datei total → Martin Hecht, tr
- SH8504/62 Hardcopy MPS802_1526 → Ralph Hoffmann, Christoph Bertog, rg
- SH8504/126 3D-Darstellung in 19 Zeilen → Achim Vowe, ev

**Print-verbatim preserved:** no `<address class="author">` bylines modified (those stay as printed, including typos). No body text changed except the 3 prose-as-`<p>` conversions where a clear non-byline sentence had been mis-tagged.

## Test plan
- [ ] Generator builds cleanly across all issues (`python3 generate.py local`)
- [ ] No duplicate author pages remain for Hauck/Meierhofer/Leuschner/Möllmann/Ponnath/Schindowski/Spitzner
- [ ] Course-series consistency check passes (Strubs Teil 3, Tasten-Codes Teil 2, etc.)
- [ ] SH8508/184 byline `(ak)` preserved in `<address>` (print-verbatim)